### PR TITLE
adding decoder

### DIFF
--- a/pkg/json/decode.go
+++ b/pkg/json/decode.go
@@ -1,0 +1,97 @@
+package json
+
+import (
+	"strings"
+
+	"encoding/json"
+)
+
+func (u *Uuid) UnmarshalJSON(b []byte) error {
+
+	var s string
+	//todo:find better way to convert [,] to byte
+	//remove outer square brackets if there are any.
+	if b[0] == []byte("[")[0] && b[len(b)-1] == []byte("]")[0] {
+		b = b[1 : len(b)-1]
+	}
+	err := UnmarshalJSON(b, &s)
+	if err != nil {
+		return err
+	}
+	*u = Uuid(s)
+	return nil
+}
+func (u *Set) UnmarshalJSON(b []byte) error {
+	k := make([]string, 0)
+	//todo:to find better way to convert [,] to byte
+	//add outer square brackets if there is no brackets.
+	if b[0] != []byte("[")[0] && b[len(b)-1] != []byte("]")[0] {
+		b = append([]byte("["), b...)
+		b = append(b, []byte("]")...)
+	}
+	err := UnmarshalJSON(b, &k)
+	if err != nil {
+		return err
+	}
+	*u = Set(k)
+	return nil
+}
+
+func processStr(str string) string {
+	processMaps := func(str string) string {
+		mapSubstrings := strings.Split(str, `["map",[`)
+		res := mapSubstrings[0]
+		for _, mapSubstring := range mapSubstrings[1:] {
+			splittedSubstring := strings.SplitN(mapSubstring, `]]]`, 2)
+			mapToEdit := splittedSubstring[0]
+			restOfSubstring := splittedSubstring[1]
+			mapToEdit = strings.ReplaceAll(mapToEdit, `","`, `":"`)
+			mapToEdit = strings.ReplaceAll(mapToEdit, `],[`, `,`)
+			mapToEdit = strings.ReplaceAll(mapToEdit, `]`, ``)
+			mapToEdit = strings.ReplaceAll(mapToEdit, `[`, ``)
+			res += `{` + mapToEdit + `}` + restOfSubstring
+		}
+		return res
+	}
+	processSets := func(str string) string {
+		ProccessSetsWithMultipleElements := func(str string) string {
+			setSubstrings := strings.Split(str, `["set",[`)
+			res := setSubstrings[0]
+			for _, setSubstring := range setSubstrings[1:] {
+				splitted := strings.SplitN(setSubstring, `]]`, 2)
+				setToEdit := splitted[0]
+				rest := splitted[1]
+				setToEdit = strings.ReplaceAll(setToEdit, `"uuid",`, ``)
+				setToEdit = strings.ReplaceAll(setToEdit, `],[`, `,`)
+				setToEdit = strings.ReplaceAll(setToEdit, `]`, ``)
+				setToEdit = strings.ReplaceAll(setToEdit, `[`, ``)
+				if rest[0] != ']' {
+					rest = `]` + rest
+				}
+				res += `[` + setToEdit + rest
+			}
+			return res
+		}
+		//ProccessSetWithSingleElement assums that we called earlier to ProccessSetsWithMultipleElements on the input str
+		ProccessSetWithSingleElement := func(str string) string {
+			setSubstrings := strings.Split(str, `:["uuid",`)
+			res := setSubstrings[0]
+			for _, setSubstring := range setSubstrings[1:] {
+				splittedSubstring := strings.SplitN(setSubstring, `]`, 2)
+				setToEdit := splittedSubstring[0]
+				restOfSubstring := splittedSubstring[1]
+				res += ":[" + setToEdit + "]" + restOfSubstring
+			}
+			return res
+		}
+		return ProccessSetWithSingleElement(ProccessSetsWithMultipleElements(str))
+	}
+	s := processSets(processMaps(str))
+	s = strings.ReplaceAll(s, `\"`, `\\\"`) //escaping the backslash char
+	return s
+}
+
+func UnmarshalJSON(b []byte, v interface{}) error {
+	s := processStr(string(b))
+	return json.Unmarshal([]byte(s), v)
+}

--- a/pkg/json/types.go
+++ b/pkg/json/types.go
@@ -8,7 +8,7 @@ type NamedUuid string
 
 type Map map[string]string
 
-type Set []interface{}
+type Set []string
 
 type EmptyStruct struct{}
 


### PR DESCRIPTION
this PR is adding the `json` decoder.
```go
func UnmarshalJSON(b []byte, v interface{}) error
```
the decoder will first manipulate the input string and unmarshall the manipulated string.
### how to use the decoder
let's say for example we want to decode the string `database_1_json ` that represent a struct from the type `_Server.Database` .

in order to do that we can use the following pattern:
```go
database_1_json = `{"name":"_Server","model":"standalone","connected":true,"schema":"{\"cksum\":\"3236486585 698\",\"name\":\"_Server\",\"tables\":{\"Database\":{\"columns\":{\"cid\":{\"type\":{\"key\":\"uuid\",\"min\":0}},\"connected\":{\"type\":\"boolean\"},\"index\":{\"type\":{\"key\":\"integer\",\"min\":0}},\"leader\":{\"type\":\"boolean\"},\"model\":{\"type\":{\"key\":{\"enum\":[\"set\",[\"clustered\",\"standalone\"]],\"type\":\"string\"}}},\"name\":{\"type\":\"string\"},\"schema\":{\"type\":{\"key\":\"string\",\"min\":0}},\"sid\":{\"type\":{\"key\":\"uuid\",\"min\":0}}}}},\"version\":\"1.1.0\"}","leader":true}`
var res _Server.Database
err := json.UnmarshalJSON([]byte(input), &res)
if err != nil {
	panic(err.Error()
}
//res is holding the decoded type
```

### a note about `Set` type
in order to decode properly some struct from the input,make sure there are no fields containing the `[]string` type.instead you can replace those with `json.Set` Type (that is defined as `type Set []string`).
that will solve the issue that a field that need to decoded as `string` and a field that need to decoded as `Set` can be appear on the same way on the input :`{...,"Field:"data",...}`.
