### PR TITLE
Cleanup: serverLoop, collumns -> strings

### DIFF
--- a/pkg/common/convert.go
+++ b/pkg/common/convert.go
@@ -62,8 +62,8 @@ func BytesToOperation(in []byte) *libovsdb.Operation {
 	return &result
 }
 
-func ArrayToMap(in []string) map[interface{}]bool {
-	ret := map[interface{}]bool{}
+func StringArrayToMap(in []string) map[string]bool {
+	ret := map[string]bool{}
 	for _, str := range in {
 		ret[str] = true
 	}

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -217,6 +217,7 @@ func (ch *Handler) getMonitoredData(dataBase string, conditions map[string][]ovs
 	returnData := ovsjson.TableUpdates{}
 	for tableName, mcrs := range conditions {
 		if len(mcrs) > 1 {
+			// TODO deal with the array
 			klog.Warningf("MCR is not a singe %v", mcrs)
 		}
 		if mcrs[0].Select != nil && !mcrs[0].Select.Initial {
@@ -226,7 +227,6 @@ func (ch *Handler) getMonitoredData(dataBase string, conditions map[string][]ovs
 		if err != nil {
 			return nil, err
 		}
-
 		d1 := ovsjson.TableUpdate{}
 		for _, v := range resp.Kvs {
 			data := map[string]interface{}{}
@@ -242,7 +242,7 @@ func (ch *Handler) getMonitoredData(dataBase string, conditions map[string][]ovs
 				delete(data, "uuid")
 				delete(data, "_version")
 			} else {
-				columnsMap := common.ArrayToMap(mcrs[0].Columns)
+				columnsMap := common.StringArrayToMap(mcrs[0].Columns)
 				for column := range data {
 					if _, ok := columnsMap[column]; !ok {
 						delete(data, column)

--- a/pkg/ovsjson/types.go
+++ b/pkg/ovsjson/types.go
@@ -108,7 +108,7 @@ type MonitorCondRequest struct {
 
 type CondMonitorParameters struct {
 	DatabaseName string
-	JsonValue    []string // TODO
+	JsonValue    interface{} // can be nil
 	// maps table name to MonitorCondRequests
 	MonitorCondRequests map[string][]MonitorCondRequest
 	LastTxnID           string


### PR DESCRIPTION
remove unused server loop function, change `columns` type to strings

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>