### PR TITLE
Fix uuid type, prevent print empty UUIDs

### DIFF
--- a/pkg/libovsdb/notation.go
+++ b/pkg/libovsdb/notation.go
@@ -158,7 +158,7 @@ type OperationResult struct {
 	Count   int         `json:"count,omitempty"`
 	Error   string      `json:"error,omitempty"`
 	Details string      `json:"details,omitempty"`
-	UUID    UUID        `json:"uuid,omitempty"`
+	UUID    *UUID       `json:"uuid,omitempty"`
 	Rows    []ResultRow `json:"rows,omitempty"`
 }
 

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -11,6 +11,7 @@ package ovsdb
 // TODO: add schema to support GC
 // TODO: Support the "Cancel" method
 // TODO: log errors to klog
+// TODO: set and update _version
 // TODO: https://docs.openvswitch.org/en/latest/ref/ovsdb-server.7/#insert
 
 import (
@@ -344,7 +345,7 @@ func makeValue(row *map[string]interface{}) (string, error) {
 
 // TODO: we should not add uuid to etcd
 func setRowUUID(row *map[string]interface{}, uuid string) {
-	(*row)[COL_UUID] = uuid
+	(*row)[COL_UUID] = libovsdb.UUID{GoUUID: uuid}
 }
 
 const (


### PR DESCRIPTION
When `OperationResult` contains the `UUID` field  as type `UUID`, which is struct, despite on the `omitempty` tag, json prints empty structs when the filed is not set. OVSDB clients don't like it ;-)

The _uuid collomn has type UUID and not string 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>