### PR TITLE
Fix `panic: nil base type` for Set validation

### DIFF
--- a/pkg/libovsdb/schema.go
+++ b/pkg/libovsdb/schema.go
@@ -729,7 +729,7 @@ func (baseType *BaseType) ValidateUUID(value interface{}) error {
 
 func (baseType *BaseType) Validate(value interface{}) error {
 	if baseType == nil {
-		panic(fmt.Sprintf("nil base type"))
+		panic(fmt.Sprintf("nil base type, value = %v", value))
 	}
 	switch baseType.Type {
 	case TypeInteger:
@@ -805,7 +805,7 @@ func (columnSchema *ColumnSchema) ValidateSet(value interface{}) error {
 		return fmt.Errorf("set breaks max limit: %+v", value)
 	}
 	for _, val := range setval.GoSet {
-		err := columnSchema.TypeObj.Value.Validate(val)
+		err := columnSchema.TypeObj.Key.Validate(val)
 		if err != nil {
 			return fmt.Errorf("set inner value invalid: %s", err.Error())
 		}

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -111,7 +111,7 @@ var testSchemaSet *libovsdb.DatabaseSchema = &libovsdb.DatabaseSchema{
 				"string": {
 					Type: libovsdb.TypeSet,
 					TypeObj: &libovsdb.ColumnType{
-						Value: &libovsdb.BaseType{
+						Key: &libovsdb.BaseType{
 							Type: libovsdb.TypeString,
 						},
 						Max: libovsdb.Unlimited,
@@ -121,7 +121,7 @@ var testSchemaSet *libovsdb.DatabaseSchema = &libovsdb.DatabaseSchema{
 				"integer": {
 					Type: libovsdb.TypeSet,
 					TypeObj: &libovsdb.ColumnType{
-						Value: &libovsdb.BaseType{
+						Key: &libovsdb.BaseType{
 							Type: libovsdb.TypeString,
 						},
 						Max: 2,


### PR DESCRIPTION
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>