### PR TITLE
Txn monitor events

### DIFF
--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -441,22 +441,22 @@ func NewTransaction(cli *clientv3.Client, request *libovsdb.Transact) *Transacti
 }
 
 type TxnEvents struct {
-	DBName string `json:database`
-	Tables []string `json:tables`
+	DBName string   `json:"dbname"`
+	Tables []string `json:"tables"`
 }
 
 func removeDuplicates(array []string) []string {
-    if len(array) == 0 {
-        return array
-    }
-    j := 1
-    for i := 1; i < len(array); i++ {
-        if array[i] != array[i-1] {
-            array[j] = array[i]
-            j++
-        }
-    }
-    return array[:j]
+	if len(array) == 0 {
+		return array
+	}
+	j := 1
+	for i := 1; i < len(array); i++ {
+		if array[i] != array[i-1] {
+			array[j] = array[i]
+			j++
+		}
+	}
+	return array[:j]
 }
 
 func (txn *Transaction) Events() *TxnEvents {


### PR DESCRIPTION
this will extract from each Transaction struct the details needed to integrate with monitor sub-system:
1. dbname - of the transaction
2. tables - that were modified via insert,update,mutate,delete operations

the idea is that using this information per a specific client you can:
1. check if there are active monitors on any of the tables *for this client*
2. then postpone sending the transaction response until the monitor events were omitted