### PR TITLE
Fix bad JSON-RPC message

### DIFF
--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -197,7 +197,8 @@ func (ch *Handler) MonitorCond(ctx context.Context, params []interface{}) (inter
 		return nil, err
 	}
 	data, err := ch.getMonitoredData(params[0].(string), updatersMap)
-	klog.V(5).Infof("MonitorCond response to %v, params %v, err %v", ch.GetClientAddress(), params, err)
+	klog.V(5).Infof("MonitorCond response to %v, jsonValue %v, data %v, err %v",
+		ch.GetClientAddress(), params[1], data, err)
 	if err != nil {
 		ch.removeMonitor(params[1], false)
 		return nil, err
@@ -265,7 +266,7 @@ func (ch *Handler) MonitorCondChange(ctx context.Context, params []interface{}) 
 			}
 		}
 	}
-	return nil, nil
+	return ovsjson.EmptyStruct{}, nil
 }
 
 func (ch *Handler) MonitorCondSince(ctx context.Context, params []interface{}) (interface{}, error) {
@@ -276,7 +277,8 @@ func (ch *Handler) MonitorCondSince(ctx context.Context, params []interface{}) (
 		return nil, err
 	}
 	data, err := ch.getMonitoredData(params[0].(string), updatersMap)
-	klog.V(5).Infof("MonitorCondSince response to %v, params %v, err %v", ch.GetClientAddress(), params, err)
+	klog.V(5).Infof("MonitorCondSince response to %v, jsonValue %v, data %v, err %v",
+		ch.GetClientAddress(), params[1], data, err)
 	if err != nil {
 		ch.removeMonitor(params[1], false)
 		return nil, err

--- a/pkg/ovsdb/monitor.go
+++ b/pkg/ovsdb/monitor.go
@@ -154,7 +154,7 @@ func (m *dbMonitor) start() {
 
 func (hm *handlerMonitorData) notifier(ch *Handler) {
 	// we need some time to allow to the monitor calls return data
-	time.Sleep(1 * time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
 	for {
 		select {
 		case <-ch.handlerContext.Done():


### PR DESCRIPTION
According to [ovsdb-server.7](https://docs.openvswitch.org/en/latest/ref/ovsdb-server.7/#monitor-cond-change), the monitor-cond-change request should return

> The response object has the following members:
"result": null
"error": null
"id": same "id" as request

However, when result is null, or missing the client (ovn-controller) returns the following misleading message :

> jsonrpc|WARN|tcp:172.18.0.4:6642: received bad JSON-RPC message: request must have "method"
2021-06-07T14:32:30.116Z|00027|reconnect|WARN|tcp:172.18.0.4:6642: connection dropped (Protocol error)

and closes connection ;-(
This PR fixes it. 

/fix #201
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>