### PR TITLE
Fix etcd events print

### DIFF
--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -470,7 +470,7 @@ func (etcd *Etcd) EventsDump() string {
 			printable = append(printable, *ev)
 		}
 	}
-	return fmt.Sprintf("%v", printable)
+	return fmt.Sprintf("%+v", printable)
 }
 
 func NewEtcd(parent *Etcd) *Etcd {


### PR DESCRIPTION
Without this fix is very hard to separate prints of current KV from prevKV

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>