### PR TITLE
Add map/set processing for update rows with updated `monitor test`

### DIFF
--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -215,7 +215,7 @@ func (ch *Handler) MonitorCond(ctx context.Context, params []interface{}) (inter
 }
 
 func (ch *Handler) MonitorCondChange(ctx context.Context, params []interface{}) (interface{}, error) {
-		ch.log.V(5).Info("monitorCondChange request", "params", params)
+	ch.log.V(5).Info("monitorCondChange request", "params", params)
 	if len(params) != 3 {
 		err := fmt.Errorf("wrong params length for MonitorCondChange %d , params %v", len(params), params)
 		ch.log.Error(err, "monitorCondChange request")

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -215,7 +215,7 @@ func (ch *Handler) MonitorCond(ctx context.Context, params []interface{}) (inter
 }
 
 func (ch *Handler) MonitorCondChange(ctx context.Context, params []interface{}) (interface{}, error) {
-	ch.log.V(5).Info("monitorCondChange request", "params", params)
+		ch.log.V(5).Info("monitorCondChange request", "params", params)
 	if len(params) != 3 {
 		err := fmt.Errorf("wrong params length for MonitorCondChange %d , params %v", len(params), params)
 		ch.log.Error(err, "monitorCondChange request")


### PR DESCRIPTION
This PR continues https://github.com/IBM/ovsdb-etcd/pull/248 testing of `monitor_test.go` and fixing the tests:
- `TestMonitorNotifications1`
- `TestMonitorNotifications2`
- `TestMonitorNotifications3`
- `TestMonitorAddRemoveMonitor`
