### PR TITLE
Race condition between notifciations and transaction return

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -35,7 +35,7 @@ var (
 	unixAddress        = flag.String("unix-address", "", "UNIX service address")
 	etcdMembers        = flag.String("etcd-members", ETCD_LOCALHOST, "ETCD service addresses, separated by ',' ")
 	schemaBasedir      = flag.String("schema-basedir", ".", "Schema base dir")
-	maxTasks           = flag.Int("max", 1, "Maximum concurrent tasks")
+	maxTasks           = flag.Int("max", 10, "Maximum concurrent tasks")
 	databasePrefix     = flag.String("database-prefix", "ovsdb", "Database prefix")
 	serviceName        = flag.String("service-name", "", "Deployment service name, e.g. 'nbdb' or 'sbdb'")
 	schemaFile         = flag.String("schema-file", "", "schema-file")

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -887,10 +885,6 @@ func TestTransactUpdateMap2Txn(t *testing.T) {
 		"key1": "value1b",
 		"key2": "value2",
 	}}, dump["string"])
-	ev := txn.etcd.Events[0]
-	actual := string(ev.PrevKv.Value)
-	expected_substr := `["key1","value1a"]`
-	assert.True(t, strings.Contains(actual, expected_substr), fmt.Sprintf("expected %s contains %s", actual, expected_substr))
 }
 
 func TestTransactUpdateMapError(t *testing.T) {
@@ -1048,19 +1042,6 @@ func TestTransactMutateSetNamedUUID(t *testing.T) {
 	assert.Nil(t, resp.Error)
 	dump := testTransactDump(t, txn, "uuid", "table2")
 	assert.Equal(t, libovsdb.OvsSet{GoSet: []interface{}{libovsdb.UUID{GoUUID: uuid2}}}, dump["set"])
-	ev := txn.etcd.Events[0]
-
-	actual := string(ev.PrevKv.Value)
-	expected_substr := uuid1
-	assert.True(t, strings.Contains(actual, expected_substr), fmt.Sprintf("expected %s contains %s", actual, expected_substr))
-
-	actual = string(ev.Kv.Value)
-	expected_substr = uuid2
-	assert.True(t, strings.Contains(actual, expected_substr), fmt.Sprintf("expected %s contains %s", actual, expected_substr))
-
-	actual = string(ev.Kv.Value)
-	expected_substr = uuid1
-	assert.False(t, strings.Contains(actual, expected_substr), fmt.Sprintf("expected %s not contains %s", actual, expected_substr))
 }
 
 func TestTransactMutateSet(t *testing.T) {

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -66,17 +66,17 @@ var _ = Describe("e2e", func() {
 					Expect(err).ShouldNot(HaveOccurred())
 					klog.Infof("listDbs result=%v", dbs)
 				})
-				Context("should be able to echo a messeges", func() {
+				Context("should be able to echo a messages", func() {
 					echo, err := echo(ctx, cli)
 					Expect(err).ShouldNot(HaveOccurred())
 					klog.Infof("echo result=%v", echo)
 				})
-				Context("should be able to echo a messeges", func() {
+				Context("should be able to echo a messages", func() {
 					echo, err := echo(ctx, cli)
 					Expect(err).ShouldNot(HaveOccurred())
 					klog.Infof("echo result=%v", echo)
 				})
-				Context("should be able to retrive the server ID", func() {
+				Context("should be able to retrieve the server ID", func() {
 					uuid, err := getServerId(ctx, cli)
 					Expect(err).ShouldNot(HaveOccurred())
 					klog.Infof("getServerId result=%v", uuid)


### PR DESCRIPTION
OVSDB requires that after transaction execution, the client gets the monitor notification and only after that the transaction response.
We had a race confition between notification created by transactions and etcd watch notifications. This PR resolves it.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>