### PR TITLE
Support "Where" flag in conditional monitoring

### DIFF
--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -283,20 +283,20 @@ func (ch *Handler) MonitorCondChange(ctx context.Context, params []interface{}) 
 			key := common.NewTableKey(dbName, tableName)
 			_, ok := monitor.key2Updaters[key]
 			if !ok {
-				ch.log.V(6).Info("MonitorCondChange", "table", tableName, "mcr", mcrArray)
-				var updaters []updater
-				tableSchema, err := databaseSchema.LookupTable(tableName)
-				if err != nil {
-					return nil, err
-				}
-				for _, mcr := range mcrArray {
-					updater := mcrToUpdater(mcr, jsonValueString, tableSchema, monitorData.notificationType == ovsjson.Update, ch.log)
-					updaters = append(updaters, *updater)
-				}
+				ch.log.V(6).Info("MonitorCondChange adding new updater for a new table")
 				monitorData.updatersKeys = append(monitorData.updatersKeys, key)
-			} else {
-				// TODO update "existing" updaters, change "where"
 			}
+			ch.log.V(6).Info("MonitorCondChange", "table", tableName, "mcr", mcrArray)
+			var updaters []updater
+			tableSchema, err := databaseSchema.LookupTable(tableName)
+			if err != nil {
+				return nil, err
+			}
+			for _, mcr := range mcrArray {
+				updater := mcrToUpdater(mcr, jsonValueString, tableSchema, monitorData.notificationType == ovsjson.Update, ch.log)
+				updaters = append(updaters, *updater)
+			}
+			ch.monitors[dbName].key2Updaters[key] = updaters
 		}
 	}
 	return ovsjson.EmptyStruct{}, nil

--- a/pkg/ovsjson/encode_test.go
+++ b/pkg/ovsjson/encode_test.go
@@ -117,13 +117,13 @@ func TestCondMonitorParameters(t *testing.T) {
 	// ["_Server",null,{"Database":[{"where":[["model","==","standalone"],true],"select":{"modify":false,"initial":true,"insert":true,"delete":true},"columns":["model","connected"]}]}]
 	// ["_Server",null,{"Database":[{"where":[["model","==","standalone"],true],"columns":["cid","connected","index","leader","model","name","schema","sid","_version"]}]},"00000000-0000-0000-0000-000000000000"]
 	// ["_Server",null,{"Database":[{"where":[true],"columns":["cid","connected","index","leader","model","name","schema","sid","_version"]}]},"00000000-0000-0000-0000-000000000000"]
-	var s = []byte(`["_Server",["monid","OVN_Northbound"],{"Database":[{"select":{"modify":true,"initial":true,"insert":false,"delete":true},"columns":["model"]}]}]`)
+	var s = []byte(`["_Server",["monid","OVN_Northbound"],{"Database":[{"select":{"modify":true,"initial":true,"insert":false,"delete":true},"columns":["model"],"where":[["model","==","standalone"],true]}]}]`)
 	actualCMP := CondMonitorParameters{}
 	err := json.Unmarshal(s, &actualCMP)
 	assert.Nil(t, err)
 	expectedSelect := &libovsdb.MonitorSelect{Modify: libovsdb.Bool(true), Initial: libovsdb.Bool(true), Insert: libovsdb.Bool(false), Delete: libovsdb.Bool(true)}
 	mcr := MonitorCondRequest{Columns: &[]string{"model"},
-		Select: expectedSelect}
+		Select: expectedSelect, Where: &[]interface{}{[]interface{}{"model", "==", "standalone"}, true}}
 
 	jsonValue := json.RawMessage{}
 	err = json.Unmarshal([]byte("[\"monid\",\"OVN_Northbound\"]"), &jsonValue)

--- a/pkg/ovsjson/types.go
+++ b/pkg/ovsjson/types.go
@@ -123,7 +123,7 @@ const (
 
 type MonitorCondRequest struct {
 	Columns *[]string               `json:"columns,omitempty"`
-	Where   interface{}             `json:"where,omitempty"` // TODO fix type (should be []string, or [][]string, but sometimes it is boolean
+	Where   *[]interface{}          `json:"where,omitempty"`
 	Select  *libovsdb.MonitorSelect `json:"select,omitempty"`
 }
 


### PR DESCRIPTION
This PR is adding support "Where" flag in conditional monitoring.it comes into play mainly on `updater` method called `prepareRow`.
The types I covered on the tests are: `Int`,`float64` (a.k.a in `ovs` terms :`real`),`UUID`,`string`,`bool` and the types still need to cover are: `map` , `set` and `Enum`.

## Known issues / notes
### (1) mock logger
when using `prepareRow` we eventually calling `NewCondition` (the call hierarchy: `prepareRow`->`isRowAppearOnWhere`->`NewCondition`). 
```go
func NewCondition(tableSchema *libovsdb.TableSchema, mapUUID MapUUID, condition []interface{}, log logr.Logger) (*Condition, error)
```
Notice that one of `NewCondition` parameters is `log logr.Logger`. Neither `prepareRow` parameters nor `updater` have access to a logger. Currently I creating a mock logger to avoid `nil` de referencing on `NewCondition` execution.
You can see that on `pkg/ovsdb/monitor.go` line `579-580`
```go
log := klogr.New() // TODO: propogate real loger insted of this generic one
res, err := NewCondition(u.tableSchema, nil, condition, log)
```
*Note:* a logger was added to `updater` so `prepareRow` can supply the logger to condition related calls.

### (2) uncovered column type test
As stated above, the types that our tests do not cover yet are: `map` , `set` and `Enum`.
### (3) interchangeable functions
We need to understand if ( `==`  , `lnclude` ) and  (`!=` , `exclude` ) are interchangeable or not on the original `OVS` protocol . Currently we treat them on the same way.
It is reasonable to assume that `lnclude` and `==`  are not the same on group element (like `set` or `map`).
**edit:**
<!-- as stated on the [https://datatracker.ietf.org/doc/html/rfc7047#section-3.2](RFC - Schema Format) -->
as stated on the [RFC - Schema Format](https://datatracker.ietf.org/doc/html/rfc7047#section-3.2)

 `includes` is equivalent to `==` and `excludes` is equivalent to `!= ` for the following types:
- `boolean`
- `string`
-  `uuid`
- `integers` 
- `real`

`includes` is **not** equivalent to `==` and `excludes` is **not** equivalent to `!= ` for the following types:
- `map`
- `set`
###### TODO
- [ ] fix `CompareMap` function on `condition.go`
- [ ] fix `CompareSet` function on `condition.go`
- [ ] check correctness of function with schema during Condition (Monitor) creation.
### (4) meaningless functions return
We need to understand what the original `OVS` protocol is doing when it receives a function that is meaningless to a specific column and act the same way.
An example for meaningless functions - what is the return value of the functions `>`,`<`,`<=`,`>=` on a `map`? 
Currently `prepareRow` return on such cases an empty row.

*Note:* OVSDB clients return error
<!---
### (5) JSON parsing
`prepareRow` is calling `unmarshalData`
```go
func (u *updater) prepareRow(value []byte) (map[string]interface{}, string, error) {                                                                                           
data, err := unmarshalData(value)                                                                                                                                          
if err != nil {                                                                                                                                                            
  return nil, "", err                                                                                                                                                    
}
...
```
as one can read on [stackoverflow](https://stackoverflow.com/questions/55436628/json-decoded-value-is-treated-as-float64-instead-of-int/55436758) :
```
To unmarshal JSON into an interface value, Unmarshal stores one of these in the interface value:
float64, for JSON numbers
```
Therefor, `prepareRow` will always receive columns with `float64` numbers as their underlying type.
`prepareRow` can return an empty row ,the input row or reduced version of the input row.for that reason `prepareRow` **cannot** return row that contain columns with `int` numbers as their underlying type. And that's can be somewhat confusing.
for that reason, when we test the `Where` flag for the `Int` type cases (as you can see on `pkg/ovsdb/monitor_test.go` on `TestMonitorPrepareRowCheckWhere`):
1. update the `Int` type on the Schema (see `createTestTableSchema`) as expected.
```go
tableSchema.Columns["i1"] = &columnSchemaInt
```
2. initializing the input row with `float64` (notice`"i1": 3.0`):
```go
dataRow := map[string]interface{}{"c1": "v1", "c2": "v2", "r1": 1.5, "i1": 3.0, "b1": true}
```

*Note:* why do you need to know exact type? Condition operations for integer and real are the same, and you don't have to use goLang compare operations, but the check "<" "=="....
-->