### PR TITLE
Add permonent cache and remove the first Trx

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lithammer/shortuuid/v3 v3.0.7
 	github.com/onsi/ginkgo v1.16.1
 	github.com/onsi/gomega v1.11.0
+	github.com/pkg/errors v0.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
@@ -23,6 +24,7 @@ require (
 	go.uber.org/zap v1.17.0 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	google.golang.org/genproto v0.0.0-20201210142538-e3217bee35cc // indirect
+	k8s.io/klog v1.0.0
 	k8s.io/klog/v2 v2.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -70,6 +70,7 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
 github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -485,6 +486,8 @@ honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
+k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
 k8s.io/klog/v2 v2.6.0 h1:c1wFxejFMBkp/VxCdc6kYdgrBkC2gzmcl6afuJAkJyU=
 k8s.io/klog/v2 v2.6.0/go.mod h1:hy9LJ/NvuK+iVyP4Ehqva4HxZG/oXyIS3n3Jmire4Ec=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -19,9 +19,8 @@ import (
 	"github.com/creachadair/jrpc2/channel"
 	"github.com/creachadair/jrpc2/handler"
 	"github.com/creachadair/jrpc2/metrics"
-
 	"github.com/go-logr/logr"
-	klog "k8s.io/klog/v2"
+	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
 
 	"github.com/ibm/ovsdb-etcd/pkg/common"
@@ -110,7 +109,7 @@ func main() {
 	}
 	defer cli.Close()
 
-	db, _ := ovsdb.NewDatabaseEtcd(cli)
+	db, _ := ovsdb.NewDatabaseEtcd(cli, log)
 
 	err = db.AddSchema(path.Join(*schemaBasedir, "_server.ovsschema"))
 	if err != nil {
@@ -123,6 +122,7 @@ func main() {
 		log.Error(err, "failed to add schema")
 		os.Exit(1)
 	}
+
 	// TODO for development only, will be remove later
 	if *loadServerDataFlag {
 		err = loadServerData(db.(*ovsdb.DatabaseEtcd))

--- a/pkg/common/key.go
+++ b/pkg/common/key.go
@@ -82,6 +82,10 @@ func (k *Key) ToTableKey() Key {
 	return Key{Prefix: k.Prefix, DBName: k.DBName, TableName: k.TableName}
 }
 
+func (k *Key) IsCommentKey() bool {
+	return k.TableName == COMMENTS
+}
+
 /* GenerateUUID generate RFC4122 UUID */
 func GenerateUUID() string {
 	return guuid.NewString()

--- a/pkg/libovsdb/map.go
+++ b/pkg/libovsdb/map.go
@@ -42,7 +42,7 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 	if err := json.Unmarshal(b, &oMap); err == nil && len(oMap) > 1 {
 		innerSlice := oMap[1].([]interface{})
 		for _, val := range innerSlice {
-			f, ok  := val.([]interface{})
+			f, ok := val.([]interface{})
 			if !ok {
 				return fmt.Errorf("innerSlice type is not []interface{}, it's %T", val)
 			}

--- a/pkg/libovsdb/map.go
+++ b/pkg/libovsdb/map.go
@@ -3,6 +3,7 @@ package libovsdb
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"reflect"
 )
 
@@ -41,7 +42,10 @@ func (o *OvsMap) UnmarshalJSON(b []byte) (err error) {
 	if err := json.Unmarshal(b, &oMap); err == nil && len(oMap) > 1 {
 		innerSlice := oMap[1].([]interface{})
 		for _, val := range innerSlice {
-			f := val.([]interface{})
+			f, ok  := val.([]interface{})
+			if !ok {
+				return fmt.Errorf("innerSlice type is not []interface{}, it's %T", val)
+			}
 			o.GoMap[f[0]] = f[1]
 		}
 	}

--- a/pkg/libovsdb/notation.go
+++ b/pkg/libovsdb/notation.go
@@ -6,6 +6,29 @@ import (
 	"fmt"
 )
 
+const (
+	// OperationInsert is an insert operation
+	OperationInsert = "insert"
+	// OperationSelect is a select operation
+	OperationSelect = "select"
+	// OperationUpdate is an update operation
+	OperationUpdate = "update"
+	// OperationMutate is a mutate operation
+	OperationMutate = "mutate"
+	// OperationDelete is a delete operation
+	OperationDelete = "delete"
+	// OperationWait is a wait operation
+	OperationWait = "wait"
+	// OperationCommit is a commit operation
+	OperationCommit = "commit"
+	// OperationAbort is an abort operation
+	OperationAbort = "abort"
+	// OperationComment is a comment operation
+	OperationComment = "comment"
+	// OperationAssert is an assert operation
+	OperationAssert = "assert"
+)
+
 // Operation represents an operation according to RFC7047 section 5.2
 type Operation struct {
 	Op        string                    `json:"op"`

--- a/pkg/libovsdb/schema.go
+++ b/pkg/libovsdb/schema.go
@@ -513,53 +513,70 @@ func (schemas *Schemas) Default(dbname, table string, row *map[string]interface{
 
 /* convert types */
 func UnmarshalInteger(from interface{}) (interface{}, error) {
-	data, err := json.Marshal(from)
-	if err != nil {
-		return nil, err
+	to, ok := from.(int)
+	if !ok {
+		data, err := json.Marshal(from)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(data, &to)
 	}
-	var to int
-	err = json.Unmarshal(data, &to)
-	return to, err
+	return to, nil
 }
 
 func UnmarshalReal(from interface{}) (interface{}, error) {
-	data, err := json.Marshal(from)
-	if err != nil {
-		return nil, err
+	to, ok := from.(float64)
+	if !ok {
+		data, err := json.Marshal(from)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(data, &to)
 	}
-	var to float64
-	err = json.Unmarshal(data, &to)
-	return to, err
+	return to, nil
 }
 
 func UnmarshalString(from interface{}) (interface{}, error) {
-	data, err := json.Marshal(from)
-	if err != nil {
-		return nil, err
+	to, ok := from.(string)
+	if !ok {
+		data, err := json.Marshal(from)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(data, &to)
 	}
-	var to string
-	err = json.Unmarshal(data, &to)
-	return to, err
+	return to, nil
 }
 
 func UnmarshalBoolean(from interface{}) (interface{}, error) {
-	data, err := json.Marshal(from)
-	if err != nil {
-		return nil, err
+	to, ok := from.(bool)
+	if !ok {
+		data, err := json.Marshal(from)
+		if err != nil {
+			return nil, err
+		}
+		err = json.Unmarshal(data, &to)
 	}
-	var to bool
-	err = json.Unmarshal(data, &to)
-	return to, err
+	return to, nil
 }
 
 func UnmarshalUUID(from interface{}) (interface{}, error) {
-	data, err := json.Marshal(from)
-	if err != nil {
-		return nil, err
+	to, ok := from.(UUID)
+	if ok {
+		return to, nil
 	}
-	var to UUID
-	err = json.Unmarshal(data, &to)
-	return to, err
+	array, ok := from.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("cannot convert %T to []interface{}, %v", from, from)
+	}
+	if len(array) != 2 {
+		return nil, fmt.Errorf("wrong array size %d", len(array))
+	}
+	uuid, ok := array[1].(string)
+	if !ok {
+		return nil, fmt.Errorf("cannot convert the second UUID member %#v to string, %v", array[1])
+	}
+	return UUID{GoUUID: uuid}, nil
 }
 
 func UnmarshalEnum(from interface{}) (interface{}, error) {
@@ -593,11 +610,14 @@ func (baseType *BaseType) Unmarshal(from interface{}) (interface{}, error) {
 }
 
 func (columnSchema *ColumnSchema) UnmarshalSet(from interface{}) (interface{}, error) {
+	to1, ok := from.(OvsSet)
+	if ok {
+		return to1, nil
+	}
 	data, err := json.Marshal(from)
 	if err != nil {
 		return nil, err
 	}
-	var to1 OvsSet
 	err = json.Unmarshal(data, &to1)
 	if err != nil {
 		return nil, err
@@ -616,11 +636,14 @@ func (columnSchema *ColumnSchema) UnmarshalSet(from interface{}) (interface{}, e
 }
 
 func (columnSchema *ColumnSchema) UnmarshalMap(from interface{}) (interface{}, error) {
+	to1, ok := from.(OvsMap)
+	if ok {
+		return to1, nil
+	}
 	data, err := json.Marshal(from)
 	if err != nil {
 		return nil, err
 	}
-	var to1 OvsMap
 	err = json.Unmarshal(data, &to1)
 	if err != nil {
 		return nil, err

--- a/pkg/libovsdb/schema.go
+++ b/pkg/libovsdb/schema.go
@@ -574,7 +574,7 @@ func UnmarshalUUID(from interface{}) (interface{}, error) {
 	}
 	uuid, ok := array[1].(string)
 	if !ok {
-		return nil, fmt.Errorf("cannot convert the second UUID member %#v to string, %v", array[1])
+		return nil, fmt.Errorf("cannot convert the second UUID member %#v to string, it's type %T", array[1], array[1])
 	}
 	return UUID{GoUUID: uuid}, nil
 }

--- a/pkg/libovsdb/set.go
+++ b/pkg/libovsdb/set.go
@@ -7,7 +7,7 @@ import (
 )
 
 // OvsSet is an OVSDB style set
-// RFC 7047 has a wierd (but understandable) notation for set as described as :
+// RFC 7047 has a weird (but understandable) notation for set as described as :
 // Either an <atom>, representing a set with exactly one element, or
 // a 2-element JSON array that represents a database set value.  The
 // first element of the array must be the string "set", and the

--- a/pkg/ovsdb/cache.go
+++ b/pkg/ovsdb/cache.go
@@ -1,10 +1,14 @@
 package ovsdb
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
+	"k8s.io/klog/v2"
 
 	"github.com/ibm/ovsdb-etcd/pkg/common"
 	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
@@ -12,47 +16,131 @@ import (
 
 type cache map[string]databaseCache
 
-type databaseCache map[string]tableCache
-
-// todo add revision
-type tableCache map[string]*map[string]interface{}
-
-func (c *cache) getDatabase(dbname string) databaseCache {
-	db, ok := (*c)[dbname]
-	if !ok {
-		db = databaseCache{}
-		(*c)[dbname] = db
-	}
-	return db
+type databaseCache struct {
+	dbCache map[string]tableCache
+	// etcdTrx watcher channel
+	watchChannel clientv3.WatchChan
+	// cancel function to close the etcdTrx watcher
+	cancel context.CancelFunc
 }
 
-func (c *cache) getTable(dbname, table string) tableCache {
-	db := c.getDatabase(dbname)
-	tb, ok := db[table]
+type tableCache map[string]*mvccpb.KeyValue
+
+func (tc *tableCache) size() int {
+	return len(*tc)
+}
+
+func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client) error {
+	if _, ok := (*c)[dbName]; ok {
+		return errors.New("Duplicate DatabaseCashe: " + dbName)
+	}
+	dbCach := databaseCache{dbCache: map[string]tableCache{}}
+	ctxt, cancel := context.WithCancel(context.Background())
+	dbCach.cancel = cancel
+	key := common.NewDBPrefixKey(dbName)
+	resp, err := etcdClient.Get(ctxt, key.String(), clientv3.WithPrefix())
+	if err != nil {
+		klog.Errorf("GetKeyData: %s", err)
+		return err
+	}
+	wch := etcdClient.Watch(clientv3.WithRequireLeader(ctxt), key.String(),
+		clientv3.WithPrefix(),
+		clientv3.WithCreatedNotify(),
+		clientv3.WithPrevKV())
+	dbCach.watchChannel = wch
+	(*c)[dbName] = dbCach
+	(*c).PutEtcdKV(resp.Kvs)
+	go func() {
+		// TODO propagate to monitors
+		for wresp := range dbCach.watchChannel {
+			if wresp.Canceled {
+				// TODO: reconnect ?
+				return
+			}
+			dbCach.updateCache(wresp.Events)
+		}
+	}()
+	return nil
+}
+
+func (dc *databaseCache) updateCache(events []*clientv3.Event) {
+	for _, event := range events {
+		key, err := common.ParseKey(string(event.Kv.Key))
+		if err != nil {
+			// TODO log
+		}
+		if key.IsCommentKey() {
+			continue
+		}
+		tb := dc.getTable(key.TableName)
+		if event.Type == mvccpb.DELETE {
+			delete(*tb, key.UUID)
+		} else {
+			(*tb)[key.UUID] = event.Kv
+		}
+	}
+}
+
+func (dc *databaseCache) getTable(tableName string) *tableCache {
+	tb, ok := dc.dbCache[tableName]
 	if !ok {
 		tb = tableCache{}
-		db[table] = tb
+		dc.dbCache[tableName] = tb
 	}
-	return tb
+	return &tb
 }
 
-func (c *cache) Row(key common.Key) *map[string]interface{} {
-	tb := c.getTable(key.DBName, key.TableName)
-	_, ok := tb[key.UUID]
+func (dc *databaseCache) size() int {
+	var ret int
+	for _, tbCache := range dc.dbCache {
+		ret += tbCache.size()
+	}
+	return ret
+}
+
+func (c *cache) size() int {
+	var ret int
+	for _, dbCache := range *c {
+		ret += dbCache.size()
+	}
+	return ret
+}
+
+func (c *cache) getDatabase(dbname string) *databaseCache {
+	db, ok := (*c)[dbname]
 	if !ok {
-		tb[key.UUID] = new(map[string]interface{})
+		db = databaseCache{dbCache: map[string]tableCache{}}
+		(*c)[dbname] = db
 	}
-	return tb[key.UUID]
+	return &db
 }
 
-func (c *cache) GetFromEtcdKV(kvs []*mvccpb.KeyValue) error {
-	for _, x := range kvs {
-		kv, err := NewKeyValue(x)
+func (c *cache) getTable(dbname, table string) *tableCache {
+	db := c.getDatabase(dbname)
+	tb, ok := db.dbCache[table]
+	if !ok {
+		tb = tableCache{}
+		db.dbCache[table] = tb
+	}
+	return &tb
+}
+
+func (c *cache) Row(key common.Key) *mvccpb.KeyValue {
+	tb := c.getTable(key.DBName, key.TableName)
+	return (*tb)[key.UUID]
+}
+
+func (c *cache) PutEtcdKV(kvs []*mvccpb.KeyValue) error {
+	for _, kv := range kvs {
+		if kv == nil {
+			continue
+		}
+		key, err := common.ParseKey(string(kv.Key))
 		if err != nil {
 			return err
 		}
-		row := c.Row(kv.Key)
-		(*row) = kv.Value
+		tb := c.getTable(key.DBName, key.TableName)
+		(*tb)[key.UUID] = kv
 	}
 	return nil
 }
@@ -61,13 +149,13 @@ func (cache *cache) GetFromEtcd(res *clientv3.TxnResponse) {
 	for _, r := range res.Responses {
 		switch v := r.Response.(type) {
 		case *etcdserverpb.ResponseOp_ResponseRange:
-			cache.GetFromEtcdKV(v.ResponseRange.Kvs)
+			cache.PutEtcdKV(v.ResponseRange.Kvs)
 		}
 	}
 }
 
 func (cache *cache) Unmarshal(log logr.Logger, schema *libovsdb.DatabaseSchema) error {
-	// TODO remove database
+	/*// TODO remove database
 	for _, databaseCache := range *cache {
 		for table, tableCache := range databaseCache {
 			for _, row := range tableCache {
@@ -78,12 +166,12 @@ func (cache *cache) Unmarshal(log logr.Logger, schema *libovsdb.DatabaseSchema) 
 				}
 			}
 		}
-	}
+	}*/
 	return nil
 }
 
 func (cache *cache) Validate(dataBase string, schema *libovsdb.DatabaseSchema, log logr.Logger) error {
-	databaseCache := cache.getDatabase(dataBase)
+	/*databaseCache := cache.getDatabase(dataBase)
 	for table, tableCache := range databaseCache {
 		for _, row := range tableCache {
 			err := schema.Validate(table, row)
@@ -92,6 +180,43 @@ func (cache *cache) Validate(dataBase string, schema *libovsdb.DatabaseSchema, l
 				return err
 			}
 		}
-	}
+	}*/
 	return nil
 }
+
+/*
+type KeyValue struct {
+	Key   common.Key
+	Value map[string]interface{}
+}
+
+func NewKeyValue(etcdKV *mvccpb.KeyValue) (*KeyValue, error) {
+	if etcdKV == nil {
+		return nil, fmt.Errorf("nil etcdKV")
+	}
+	kv := new(KeyValue)
+
+	/ * key * /
+	if etcdKV.Key == nil {
+		return nil, fmt.Errorf("nil key")
+	}
+	key, err := common.ParseKey(string(etcdKV.Key))
+	if err != nil {
+		return nil, err
+	}
+	kv.Key = *key
+	/ * value * /
+	err = json.Unmarshal(etcdKV.Value, &kv.Value)
+	if err != nil {
+		return nil, err
+	}
+
+	return kv, nil
+}
+func ParseKey(etcdKV *mvccpb.KeyValue) ( *common.Key, error) {
+	if etcdKV == nil {
+		return nil, fmt.Errorf("nil etcdKV")
+	}
+	return common.ParseKey(string(etcdKV.Key))
+}
+*/

--- a/pkg/ovsdb/condition_test.go
+++ b/pkg/ovsdb/condition_test.go
@@ -1,0 +1,30 @@
+package ovsdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/klog/klogr"
+
+	"github.com/ibm/ovsdb-etcd/pkg/common"
+	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
+)
+
+func TestConditionUUID(t *testing.T) {
+	table := "table1"
+	common.SetPrefix("ovsdb/nb")
+	uuid := common.GenerateUUID()
+	goUUID := libovsdb.UUID{GoUUID: uuid}
+
+	cond := []interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}
+	tableSchema, ok := testSchemaSimple.Tables[table]
+	assert.True(t, ok)
+	pCondition, err := NewCondition(&tableSchema, nil, cond, klogr.New())
+	assert.Nil(t, err)
+	condition := *pCondition
+	uuidStr, err := condition.getUUIDIfExists()
+	assert.Nil(t, err)
+	assert.Equal(t, uuid, uuidStr)
+}
+
+// TODO add tests

--- a/pkg/ovsdb/monitor.go
+++ b/pkg/ovsdb/monitor.go
@@ -114,6 +114,10 @@ func (tq *transactionsQueue) startTransaction() {
 	tq.mu.Lock()
 }
 
+func (tq *transactionsQueue) abbortTransaction() {
+	tq.mu.Unlock()
+}
+
 func (tq *transactionsQueue) endTransaction(rev int64, wg *sync.WaitGroup) {
 	// we are holding the lock
 	qe := queueElement{revision: rev, wg: wg}

--- a/pkg/ovsdb/monitor_test.go
+++ b/pkg/ovsdb/monitor_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
-	klog "k8s.io/klog/v2"
-	klogr "k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2"
+	"k8s.io/klog/v2/klogr"
 
 	"github.com/ibm/ovsdb-etcd/pkg/common"
 	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"

--- a/pkg/ovsdb/mutation.go
+++ b/pkg/ovsdb/mutation.go
@@ -20,11 +20,11 @@ const (
 )
 
 type Mutation struct {
-	Column       string
-	Mutator      string
-	Value        interface{}
-	ColumnSchema *libovsdb.ColumnSchema
-	Log          logr.Logger
+	column       string
+	mutator      string
+	value        interface{}
+	columnSchema *libovsdb.ColumnSchema
+	log          logr.Logger
 }
 
 func NewMutation(tableSchema *libovsdb.TableSchema, mapUUID namedUUIDResolver, mutation []interface{}, log logr.Logger) (*Mutation, error) {
@@ -57,13 +57,18 @@ func NewMutation(tableSchema *libovsdb.TableSchema, mapUUID namedUUIDResolver, m
 	}
 
 	value := mutation[2]
-	value, err = columnSchema.Unmarshal(value)
-	if err != nil {
-		// value for mutate map with delete mutator can be map or set
-		if columnSchema.Type == libovsdb.TypeMap || mt == MT_DELETE {
-			value, err = columnSchema.UnmarshalSet(value)
+	if columnSchema.Type == libovsdb.TypeSet && isSetScalarOperation(columnSchema.TypeObj.Key.Type, mt) {
+		value, err = columnSchema.TypeObj.Key.Unmarshal(value)
+	} else {
+		value, err = columnSchema.Unmarshal(value)
+		if err != nil {
+			// value for mutate map with delete mutator can be map or set
+			if columnSchema.Type == libovsdb.TypeMap || mt == MT_DELETE {
+				value, err = columnSchema.UnmarshalSet(value)
+			}
 		}
 	}
+
 	if err != nil {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
 		log.Error(err, "failed unmarshal of column", "column", column)
@@ -73,23 +78,23 @@ func NewMutation(tableSchema *libovsdb.TableSchema, mapUUID namedUUIDResolver, m
 	value, err = mapUUID.Resolve(value, log)
 	if err != nil {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		log.Error(err, "failed resolv-namedUUID of column", "column", column)
+		log.Error(err, "failed resolve namedUUID of column", "column", column)
 		return nil, err
 	}
 
-	err = columnSchema.Validate(value)
+	/*err = columnSchema.Validate(value)
 	if err != nil {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
 		log.Error(err, "failed validate of column", "column", column)
 		return nil, err
-	}
+	}*/
 
 	m := &Mutation{
-		Column:       column,
-		Mutator:      mt,
-		Value:        value,
-		ColumnSchema: columnSchema,
-		Log:          log,
+		column:       column,
+		mutator:      mt,
+		value:        value,
+		columnSchema: columnSchema,
+		log:          log,
 	}
 	if err = m.validateMutator(); err != nil {
 		return nil, err
@@ -98,115 +103,64 @@ func NewMutation(tableSchema *libovsdb.TableSchema, mapUUID namedUUIDResolver, m
 }
 
 func (m *Mutation) validateMutator() error {
-	switch m.ColumnSchema.Type {
+	switch m.columnSchema.Type {
 	case libovsdb.TypeReal, libovsdb.TypeInteger:
-		switch m.Mutator {
+		switch m.mutator {
 		case MT_DIFFERENCE, MT_PRODUCT, MT_QUOTIENT, MT_SUM:
 			return nil
 		case MT_REMAINDER:
-			if m.ColumnSchema.Type == libovsdb.TypeInteger {
+			if m.columnSchema.Type == libovsdb.TypeInteger {
 				return nil
 			}
 		}
-	case libovsdb.TypeMap, libovsdb.TypeSet:
-		if m.Mutator == MT_INSERT || m.Mutator == MT_DELETE {
+	case libovsdb.TypeMap:
+		if m.mutator == MT_INSERT || m.mutator == MT_DELETE {
 			return nil
 		}
-		if m.ColumnSchema.Type == libovsdb.TypeSet {
-			valueType := m.ColumnSchema.TypeObj.Value.Type
-			if valueType == libovsdb.TypeReal || valueType == libovsdb.TypeInteger {
-				switch m.Mutator {
-				case MT_DIFFERENCE, MT_PRODUCT, MT_QUOTIENT, MT_SUM:
-					return nil
-				case MT_REMAINDER:
-					if m.ColumnSchema.Type == libovsdb.TypeInteger {
-						return nil
-					}
-				}
-			}
-			err := errors.New(E_CONSTRAINT_VIOLATION)
-			m.Log.Error(err, "incompatible mutator", "mutator", m.Mutator, "set value type", valueType)
-			return err
+	case libovsdb.TypeSet:
+		if m.mutator == MT_INSERT || m.mutator == MT_DELETE {
+			return nil
+		}
+		if isSetScalarOperation(m.columnSchema.TypeObj.Key.Type, m.mutator) {
+			return nil
 		}
 	}
 	err := errors.New(E_CONSTRAINT_VIOLATION)
-	m.Log.Error(err, "incompatible mutator", "mutator", m.Mutator, "column type", m.ColumnSchema.Type)
+	m.log.Error(err, "incompatible mutator", "mutator", m.mutator, "column type", m.columnSchema.Type)
 	return err
 }
 
-func (m *Mutation) MutateInteger(row *map[string]interface{}) error {
+func (m *Mutation) mutateInteger(row *map[string]interface{}) error {
 	var err error
-	original := (*row)[m.Column].(int)
-	value, ok := m.Value.(int)
+	original := (*row)[m.column].(int)
+	value, ok := m.value.(int)
 	if !ok {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "can't convert mutation value", "value", m.Value)
+		m.log.Error(err, "can't convert mutation value", "value", m.value)
 		return err
 	}
-	mutated := original
-	switch m.Mutator {
-	case MT_SUM:
-		mutated += value
-	case MT_DIFFERENCE:
-		mutated -= value
-	case MT_PRODUCT:
-		mutated *= value
-	case MT_QUOTIENT:
-		if value != 0 {
-			mutated /= value
-		} else {
-			err = errors.New(E_DOMAIN_ERROR)
-			m.Log.Error(err, "can't devide by 0")
-			return err
-		}
-	case MT_REMAINDER:
-		if value != 0 {
-			mutated %= value
-		} else {
-			err = errors.New(E_DOMAIN_ERROR)
-			m.Log.Error(err, "can't modulo by 0")
-			return err
-		}
-	default:
-		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "unsupported mutator", "mutator", m.Mutator)
+	mutated, err := m.mutateI(original, value)
+	if err != nil {
 		return err
 	}
-	(*row)[m.Column] = mutated
+	(*row)[m.column] = mutated
 	return nil
 }
 
-func (m *Mutation) MutateReal(row *map[string]interface{}) error {
+func (m *Mutation) mutateReal(row *map[string]interface{}) error {
 	var err error
-	original := (*row)[m.Column].(float64)
-	value, ok := m.Value.(float64)
+	original := (*row)[m.column].(float64)
+	value, ok := m.value.(float64)
 	if !ok {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "failed to convert mutation value", "value", m.Value)
+		m.log.Error(err, "failed to convert mutation value", "value", m.value)
 		return err
 	}
-	mutated := original
-	switch m.Mutator {
-	case MT_SUM:
-		mutated += value
-	case MT_DIFFERENCE:
-		mutated -= value
-	case MT_PRODUCT:
-		mutated *= value
-	case MT_QUOTIENT:
-		if value != 0 {
-			mutated /= value
-		} else {
-			err = errors.New(E_DOMAIN_ERROR)
-			m.Log.Error(err, "can't devide by 0")
-			return err
-		}
-	default:
-		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "unsupported mutator", "mutator", m.Mutator)
+	mutated, err := m.mutateR(original, value)
+	if err != nil {
 		return err
 	}
-	(*row)[m.Column] = mutated
+	(*row)[m.column] = mutated
 	return nil
 }
 
@@ -219,16 +173,21 @@ func inSet(set *libovsdb.OvsSet, a interface{}) bool {
 	return false
 }
 
-func (m *Mutation) insertToSet(original *libovsdb.OvsSet, toInsert interface{}) (*libovsdb.OvsSet, error) {
+func (m *Mutation) insertToSet(original *libovsdb.OvsSet) (*libovsdb.OvsSet, error) {
 	var err error
-	toInsertSet, ok := toInsert.(libovsdb.OvsSet)
+	toInsertSet, ok := m.value.(libovsdb.OvsSet)
 	if !ok {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "failed to convert mutation value", "value", toInsert)
+		m.log.Error(err, "failed to convert mutation value", "value", m.value)
 		return nil, err
 	}
 	mutated := new(libovsdb.OvsSet)
-	copier.Copy(mutated, original)
+	err = copier.Copy(mutated, original)
+	if err != nil {
+		m.log.Error(err, "copier failed")
+		err = errors.New(E_CONSTRAINT_VIOLATION)
+		return nil, err
+	}
 	for _, v := range toInsertSet.GoSet {
 		if !inSet(original, v) {
 			mutated.GoSet = append(mutated.GoSet, v)
@@ -237,12 +196,64 @@ func (m *Mutation) insertToSet(original *libovsdb.OvsSet, toInsert interface{}) 
 	return mutated, nil
 }
 
-func (m *Mutation) deleteFromSet(original *libovsdb.OvsSet, toDelete interface{}) (*libovsdb.OvsSet, error) {
+func (m *Mutation) mutateIntegersSet(original *libovsdb.OvsSet) (*libovsdb.OvsSet, error) {
 	var err error
-	toDeleteSet, ok := toDelete.(libovsdb.OvsSet)
+	value, ok := m.value.(int)
 	if !ok {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "failed to convert mutation value", "value", toDelete)
+		m.log.Error(err, "can't convert mutation value", "value", m.value)
+		return nil, err
+	}
+
+	mutated := new(libovsdb.OvsSet)
+	for _, v := range original.GoSet {
+		intV, ok := v.(int)
+		if !ok {
+			err = errors.New(E_CONSTRAINT_VIOLATION)
+			m.log.Error(err, "can't convert mutated to int", "mutated", v)
+			return nil, err
+		}
+		newV, err := m.mutateI(intV, value)
+		if err != nil {
+			return nil, err
+		}
+		mutated.GoSet = append(mutated.GoSet, newV)
+	}
+	return mutated, nil
+}
+
+func (m *Mutation) mutateRealsSet(original *libovsdb.OvsSet) (*libovsdb.OvsSet, error) {
+	var err error
+	value, ok := m.value.(float64)
+	if !ok {
+		err = errors.New(E_CONSTRAINT_VIOLATION)
+		m.log.Error(err, "can't convert mutation value", "value", m.value)
+		return nil, err
+	}
+
+	mutated := new(libovsdb.OvsSet)
+	for _, v := range original.GoSet {
+		r, ok := v.(float64)
+		if !ok {
+			err = errors.New(E_CONSTRAINT_VIOLATION)
+			m.log.Error(err, "can't convert mutated to float64", "mutated", v)
+			return nil, err
+		}
+		newV, err := m.mutateR(r, value)
+		if err != nil {
+			return nil, err
+		}
+		mutated.GoSet = append(mutated.GoSet, newV)
+	}
+	return mutated, nil
+}
+
+func (m *Mutation) deleteFromSet(original *libovsdb.OvsSet) (*libovsdb.OvsSet, error) {
+	var err error
+	toDeleteSet, ok := m.value.(libovsdb.OvsSet)
+	if !ok {
+		err = errors.New(E_CONSTRAINT_VIOLATION)
+		m.log.Error(err, "failed to convert mutation value", "value", m.value)
 		return nil, err
 	}
 	mutated := new(libovsdb.OvsSet)
@@ -261,29 +272,44 @@ func (m *Mutation) deleteFromSet(original *libovsdb.OvsSet, toDelete interface{}
 	return mutated, nil
 }
 
-func (m *Mutation) MutateSet(row *map[string]interface{}) error {
-	original := (*row)[m.Column].(libovsdb.OvsSet)
+func (m *Mutation) mutateSet(row *map[string]interface{}) error {
+	original := (*row)[m.column].(libovsdb.OvsSet)
 	var mutated *libovsdb.OvsSet
 	var err error
-	switch m.Mutator {
+	switch m.mutator {
 	case MT_INSERT:
-		mutated, err = m.insertToSet(&original, m.Value)
+		mutated, err = m.insertToSet(&original)
 	case MT_DELETE:
-		mutated, err = m.deleteFromSet(&original, m.Value)
+		mutated, err = m.deleteFromSet(&original)
+	case MT_PRODUCT, MT_REMAINDER, MT_SUM, MT_QUOTIENT, MT_DIFFERENCE:
+		valueType := m.columnSchema.TypeObj.Key.Type
+		if valueType == libovsdb.TypeInteger {
+			mutated, err = m.mutateIntegersSet(&original)
+		} else if valueType == libovsdb.TypeReal {
+			mutated, err = m.mutateRealsSet(&original)
+		} else {
+			err = errors.New(E_CONSTRAINT_VIOLATION)
+			m.log.Error(err, "incompatible mutator and set's value type:", "mutator", m.mutator, "value type", valueType)
+		}
 	default:
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "unsupported mutation mutator:", "mutator", m.Mutator)
+		m.log.Error(err, "unsupported mutation mutator:", "mutator", m.mutator)
 	}
 	if err != nil {
 		return err
 	}
-	(*row)[m.Column] = *mutated
+	(*row)[m.column] = *mutated
 	return nil
 }
 
 func (m *Mutation) insertToMap(original *libovsdb.OvsMap, toInsert interface{}) (*libovsdb.OvsMap, error) {
 	mutated := new(libovsdb.OvsMap)
-	copier.Copy(&mutated, &original)
+	err := copier.Copy(&mutated, &original)
+	if err != nil {
+		m.log.Error(err, "copier failed")
+		err = errors.New(E_CONSTRAINT_VIOLATION)
+		return nil, err
+	}
 	switch toInsert := toInsert.(type) {
 	case libovsdb.OvsMap:
 		for k, v := range toInsert.GoMap {
@@ -293,7 +319,7 @@ func (m *Mutation) insertToMap(original *libovsdb.OvsMap, toInsert interface{}) 
 		}
 	default:
 		err := errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "unsupported mutator value type", "value", toInsert)
+		m.log.Error(err, "unsupported mutator value type", "value", toInsert)
 		return nil, err
 	}
 	return mutated, nil
@@ -301,7 +327,12 @@ func (m *Mutation) insertToMap(original *libovsdb.OvsMap, toInsert interface{}) 
 
 func (m *Mutation) deleteFromMap(original *libovsdb.OvsMap, toDelete interface{}) (*libovsdb.OvsMap, error) {
 	mutated := new(libovsdb.OvsMap)
-	copier.Copy(&mutated, &original)
+	err := copier.Copy(&mutated, &original)
+	if err != nil {
+		m.log.Error(err, "copier failed")
+		err = errors.New(E_CONSTRAINT_VIOLATION)
+		return nil, err
+	}
 	switch toDelete := toDelete.(type) {
 	case libovsdb.OvsMap:
 		for k, v := range toDelete.GoMap {
@@ -317,52 +348,129 @@ func (m *Mutation) deleteFromMap(original *libovsdb.OvsMap, toDelete interface{}
 	return mutated, nil
 }
 
-func (m *Mutation) MutateMap(row *map[string]interface{}) error {
-	original := (*row)[m.Column].(libovsdb.OvsMap)
+func (m *Mutation) mutateMap(row *map[string]interface{}) error {
+	original := (*row)[m.column].(libovsdb.OvsMap)
 	mutated := new(libovsdb.OvsMap)
 	var err error
-	switch m.Mutator {
+	switch m.mutator {
 	case MT_INSERT:
-		mutated, err = m.insertToMap(&original, m.Value)
+		mutated, err = m.insertToMap(&original, m.value)
 	case MT_DELETE:
-		mutated, err = m.deleteFromMap(&original, m.Value)
+		mutated, err = m.deleteFromMap(&original, m.value)
 	default:
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "unsupported mutation mutator", "mutator", m.Mutator)
+		m.log.Error(err, "unsupported mutation mutator", "mutator", m.mutator)
 		return err
 	}
 	if err != nil {
 		return err
 	}
-	(*row)[m.Column] = *mutated
+	(*row)[m.column] = *mutated
 	return nil
 }
 
 func (m *Mutation) Mutate(row *map[string]interface{}) error {
 	var err error
-	switch m.Column {
+	switch m.column {
 	case libovsdb.COL_UUID, libovsdb.COL_VERSION:
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "can't mutate column", "column", m.Column)
+		m.log.Error(err, "can't mutate column", "column", m.column)
 		return err
 	}
-	if m.ColumnSchema.Mutable != nil && !*m.ColumnSchema.Mutable {
+	if m.columnSchema.Mutable != nil && !*m.columnSchema.Mutable {
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "can't mutate unmutable column", "column", m.Column)
+		m.log.Error(err, "can't mutate immutable column", "column", m.column)
 		return err
 	}
-	switch m.ColumnSchema.Type {
+	switch m.columnSchema.Type {
 	case libovsdb.TypeInteger:
-		return m.MutateInteger(row)
+		return m.mutateInteger(row)
 	case libovsdb.TypeReal:
-		return m.MutateReal(row)
+		return m.mutateReal(row)
 	case libovsdb.TypeSet:
-		return m.MutateSet(row)
+		return m.mutateSet(row)
 	case libovsdb.TypeMap:
-		return m.MutateMap(row)
+		return m.mutateMap(row)
 	default:
 		err = errors.New(E_CONSTRAINT_VIOLATION)
-		m.Log.Error(err, "unsupported column schema type", "type", m.ColumnSchema.Type)
+		m.log.Error(err, "unsupported column schema type", "type", m.columnSchema.Type)
 		return err
+	}
+}
+
+func (m *Mutation) mutateI(mutated, value int) (int, error) {
+	switch m.mutator {
+	case MT_SUM:
+		mutated += value
+	case MT_DIFFERENCE:
+		mutated -= value
+	case MT_PRODUCT:
+		mutated *= value
+	case MT_QUOTIENT:
+		if value != 0 {
+			mutated /= value
+		} else {
+			err := errors.New(E_DOMAIN_ERROR)
+			m.log.Error(err, "can't divide by 0")
+			return -1, err
+		}
+	case MT_REMAINDER:
+		if value != 0 {
+			mutated %= value
+		} else {
+			err := errors.New(E_DOMAIN_ERROR)
+			m.log.Error(err, "can't modulo by 0")
+			return -1, err
+		}
+	default:
+		err := errors.New(E_CONSTRAINT_VIOLATION)
+		m.log.Error(err, "unsupported mutator", "mutator", m.mutator)
+		return -1, err
+	}
+	return mutated, nil
+}
+
+func (m *Mutation) mutateR(mutated, value float64) (float64, error) {
+	switch m.mutator {
+	case MT_SUM:
+		mutated += value
+	case MT_DIFFERENCE:
+		mutated -= value
+	case MT_PRODUCT:
+		mutated *= value
+	case MT_QUOTIENT:
+		if value != 0 {
+			mutated /= value
+		} else {
+			err := errors.New(E_DOMAIN_ERROR)
+			m.log.Error(err, "can't divide by 0")
+			return -1, err
+		}
+	default:
+		err := errors.New(E_CONSTRAINT_VIOLATION)
+		m.log.Error(err, "unsupported mutator", "mutator", m.mutator)
+		return -1, err
+	}
+	return mutated, nil
+}
+
+func isSetScalarOperation(setValuesType, mutator string) bool {
+	switch setValuesType {
+	case libovsdb.TypeInteger:
+		switch mutator {
+		case MT_DIFFERENCE, MT_PRODUCT, MT_QUOTIENT, MT_SUM, MT_REMAINDER:
+			return true
+		default:
+			return false
+		}
+	case libovsdb.TypeReal:
+		switch mutator {
+		case MT_DIFFERENCE, MT_PRODUCT, MT_QUOTIENT, MT_SUM:
+			return true
+		default:
+			return false
+		}
+	default:
+		return false
 	}
 }

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -841,7 +841,7 @@ func (txn *Transaction) RowPrepare(tableSchema *libovsdb.TableSchema, mapUUID na
 
 /* insert */
 func (txn *Transaction) doInsert(ovsOp *libovsdb.Operation, ovsResult *libovsdb.OperationResult) (err error, details string) {
-	if ovsResult.Error != nil{
+	if ovsResult.Error != nil {
 		return fmt.Errorf(*ovsResult.Error), ""
 	}
 	tableSchema, e := txn.schema.LookupTable(*ovsOp.Table)
@@ -903,7 +903,7 @@ func (txn *Transaction) doSelect(ovsOp *libovsdb.Operation, ovsResult *libovsdb.
 	}
 	uuid, e := cond.getUUIDIfSelected()
 	if e != nil {
-		errors.New(E_INTERNAL_ERROR)
+		err = errors.New(E_INTERNAL_ERROR)
 		return
 	}
 
@@ -1236,13 +1236,23 @@ func (txn *Transaction) doWait(ovsOp *libovsdb.Operation, ovsResult *libovsdb.Op
 	return
 }
 
-func (txn *Transaction) doCommit(ovsOp *libovsdb.Operation, ovsResult *libovsdb.OperationResult) (error, string) {
-	return nil, ""
+func (txn *Transaction) doCommit(ovsOp *libovsdb.Operation, ovsResult *libovsdb.OperationResult) (err error, details string) {
+	if ovsOp.Durable == nil {
+		err = errors.New(E_CONSTRAINT_VIOLATION)
+		txn.log.Error(err, "missing durable parameter")
+		return
+	}
+	if *ovsOp.Durable {
+		err = errors.New(E_NOT_SUPPORTED)
+		txn.log.Error(err, "do not support durable == true")
+		return
+	}
+	return
 }
 
 /* abort */
 func (txn *Transaction) doAbort(ovsOp *libovsdb.Operation, ovsResult *libovsdb.OperationResult) (error, string) {
-	return nil, ""
+	return errors.New(E_ABORTED), ""
 }
 
 /* comment */


### PR DESCRIPTION
Originally, most of OVSDB transaction operations were implemented as 2 etcd transactions: fetch data, process it, and store the data back in etcd.
The cache rids off the first transactions. 
Plus added an optimization for transactions that contain an explicit _uuid selector. 