### PR TITLE
Prevet concurrent modification of Handler's internal maps

### DIFF
--- a/pkg/ovsdb/cache.go
+++ b/pkg/ovsdb/cache.go
@@ -2,26 +2,27 @@ package ovsdb
 
 import (
 	"context"
+	"sync"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"go.etcd.io/etcd/api/v3/etcdserverpb"
 	"go.etcd.io/etcd/api/v3/mvccpb"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"k8s.io/klog/v2"
 
 	"github.com/ibm/ovsdb-etcd/pkg/common"
-	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
 )
 
-type cache map[string]databaseCache
+type cache map[string]*databaseCache
 
 type databaseCache struct {
+	mu      sync.Mutex
 	dbCache map[string]tableCache
 	// etcdTrx watcher channel
 	watchChannel clientv3.WatchChan
 	// cancel function to close the etcdTrx watcher
 	cancel context.CancelFunc
+	log    logr.Logger
 }
 
 type tableCache map[string]*mvccpb.KeyValue
@@ -30,11 +31,11 @@ func (tc *tableCache) size() int {
 	return len(*tc)
 }
 
-func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client) error {
+func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client, log logr.Logger) error {
 	if _, ok := (*c)[dbName]; ok {
 		return errors.New("Duplicate DatabaseCashe: " + dbName)
 	}
-	dbCach := databaseCache{dbCache: map[string]tableCache{}}
+	dbCach := databaseCache{dbCache: map[string]tableCache{}, log: log}
 	ctxt, cancel := context.WithCancel(context.Background())
 	dbCach.cancel = cancel
 	key := common.NewDBPrefixKey(dbName)
@@ -48,7 +49,7 @@ func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client) err
 		clientv3.WithCreatedNotify(),
 		clientv3.WithPrevKV())
 	dbCach.watchChannel = wch
-	(*c)[dbName] = dbCach
+	(*c)[dbName] = &dbCach
 	(*c).PutEtcdKV(resp.Kvs)
 	go func() {
 		// TODO propagate to monitors
@@ -64,10 +65,13 @@ func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client) err
 }
 
 func (dc *databaseCache) updateCache(events []*clientv3.Event) {
+	//dc.mu.Lock()
+	//defer dc.mu.Unlock()
 	for _, event := range events {
 		key, err := common.ParseKey(string(event.Kv.Key))
 		if err != nil {
-			// TODO log
+			dc.log.Error(err, "got a wrong formatted key from etcd", "key", string(event.Kv.Key))
+			continue
 		}
 		if key.IsCommentKey() {
 			continue
@@ -81,6 +85,7 @@ func (dc *databaseCache) updateCache(events []*clientv3.Event) {
 	}
 }
 
+// should be called under locked dc.mu
 func (dc *databaseCache) getTable(tableName string) *tableCache {
 	tb, ok := dc.dbCache[tableName]
 	if !ok {
@@ -109,10 +114,10 @@ func (c *cache) size() int {
 func (c *cache) getDatabase(dbname string) *databaseCache {
 	db, ok := (*c)[dbname]
 	if !ok {
-		db = databaseCache{dbCache: map[string]tableCache{}}
+		db = &databaseCache{dbCache: map[string]tableCache{}}
 		(*c)[dbname] = db
 	}
-	return &db
+	return db
 }
 
 func (c *cache) getTable(dbname, table string) *tableCache {
@@ -123,11 +128,6 @@ func (c *cache) getTable(dbname, table string) *tableCache {
 		db.dbCache[table] = tb
 	}
 	return &tb
-}
-
-func (c *cache) Row(key common.Key) *mvccpb.KeyValue {
-	tb := c.getTable(key.DBName, key.TableName)
-	return (*tb)[key.UUID]
 }
 
 func (c *cache) PutEtcdKV(kvs []*mvccpb.KeyValue) error {
@@ -144,79 +144,3 @@ func (c *cache) PutEtcdKV(kvs []*mvccpb.KeyValue) error {
 	}
 	return nil
 }
-
-func (cache *cache) GetFromEtcd(res *clientv3.TxnResponse) {
-	for _, r := range res.Responses {
-		switch v := r.Response.(type) {
-		case *etcdserverpb.ResponseOp_ResponseRange:
-			cache.PutEtcdKV(v.ResponseRange.Kvs)
-		}
-	}
-}
-
-func (cache *cache) Unmarshal(log logr.Logger, schema *libovsdb.DatabaseSchema) error {
-	/*// TODO remove database
-	for _, databaseCache := range *cache {
-		for table, tableCache := range databaseCache {
-			for _, row := range tableCache {
-				err := schema.Unmarshal(table, row)
-				if err != nil {
-					log.Error(err, "failed schema unmarshal")
-					return err
-				}
-			}
-		}
-	}*/
-	return nil
-}
-
-func (cache *cache) Validate(dataBase string, schema *libovsdb.DatabaseSchema, log logr.Logger) error {
-	/*databaseCache := cache.getDatabase(dataBase)
-	for table, tableCache := range databaseCache {
-		for _, row := range tableCache {
-			err := schema.Validate(table, row)
-			if err != nil {
-				log.Error(err, "failed schema validate")
-				return err
-			}
-		}
-	}*/
-	return nil
-}
-
-/*
-type KeyValue struct {
-	Key   common.Key
-	Value map[string]interface{}
-}
-
-func NewKeyValue(etcdKV *mvccpb.KeyValue) (*KeyValue, error) {
-	if etcdKV == nil {
-		return nil, fmt.Errorf("nil etcdKV")
-	}
-	kv := new(KeyValue)
-
-	/ * key * /
-	if etcdKV.Key == nil {
-		return nil, fmt.Errorf("nil key")
-	}
-	key, err := common.ParseKey(string(etcdKV.Key))
-	if err != nil {
-		return nil, err
-	}
-	kv.Key = *key
-	/ * value * /
-	err = json.Unmarshal(etcdKV.Value, &kv.Value)
-	if err != nil {
-		return nil, err
-	}
-
-	return kv, nil
-}
-func ParseKey(etcdKV *mvccpb.KeyValue) ( *common.Key, error) {
-	if etcdKV == nil {
-		return nil, fmt.Errorf("nil etcdKV")
-	}
-	return common.ParseKey(string(etcdKV.Key))
-}
-*/

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -412,33 +412,49 @@ Loop:
 		return -1, err
 	}
 
-	// insert name-uuid preprocessing
-	for i, ovsOp := range txn.request.Operations {
-		if ovsOp.Op == libovsdb.OperationInsert {
-			if ovsOp.UUIDName != nil {
-				if _, ok := txn.mapUUID[*ovsOp.UUIDName]; ok {
-					err = errors.New(E_DUP_UUIDNAME)
-					txn.log.Error(err, "", "uuid-name", *ovsOp.UUIDName)
-					txn.response.Result[i].SetError(E_DUP_UUIDNAME)
-				} else {
-					uuid, err := txn.generateUUID(&ovsOp)
-					if err != nil {
-						return -1, err
+	processOperations := func() error {
+		txn.cache.mu.Lock()
+		defer txn.cache.mu.Unlock()
+		// insert name-uuid preprocessing
+		for i, ovsOp := range txn.request.Operations {
+			if ovsOp.Op == libovsdb.OperationInsert {
+				if ovsOp.UUIDName != nil {
+					if _, ok := txn.mapUUID[*ovsOp.UUIDName]; ok {
+						err = errors.New(E_DUP_UUIDNAME)
+						txn.log.Error(err, "", "uuid-name", *ovsOp.UUIDName)
+						txn.response.Result[i].SetError(E_DUP_UUIDNAME)
+						// we will return error for the operation processing
+					} else {
+						// TODO
+						var uuid string
+						if ovsOp.UUID != nil {
+							uuid = ovsOp.UUID.GoUUID
+						} else {
+							uuid, err = txn.generateUUID(&ovsOp)
+							if err != nil {
+								return err
+							}
+						}
+						txn.mapUUID.Set(*ovsOp.UUIDName, uuid, txn.log)
 					}
-					txn.mapUUID.Set(*ovsOp.UUIDName, uuid, txn.log)
 				}
 			}
 		}
-	}
 
-	for i, ovsOp := range txn.request.Operations {
-		err = txn.doOperation(&ovsOp, &txn.response.Result[i])
-		if err != nil {
-			errStr := err.Error()
-			txn.response.Result[i].SetError(errStr)
-			//txn.response.Error = &errStr
-			return -1, err
+		for i, ovsOp := range txn.request.Operations {
+			err = txn.doOperation(&ovsOp, &txn.response.Result[i])
+			if err != nil {
+				errStr := err.Error()
+				txn.response.Result[i].SetError(errStr)
+				//txn.response.Error = &errStr
+				return err
+			}
 		}
+		return nil
+	}
+	err = processOperations()
+	if err != nil {
+		return -1, err
 	}
 
 	txn.etcdRemoveDup()

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -277,7 +277,7 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 	assert.Nil(t, err)
 	defer cli.Close()
 	cache := cache{}
-	cache.addDatabaseCache(schema.Name, cli)
+	cache.addDatabaseCache(schema.Name, cli, klogr.New())
 	dbCache := cache.getDatabase(schema.Name)
 	if expCacheElements > -1 {
 		var elements int


### PR DESCRIPTION
Add mutex Lock/RLock to protect handler's monitor related maps `monitors` and `handlerMonitorData`.
`databaseLocks` implements as a sync.Map.

Add locks to cache and schemas 