### PR TITLE
Fix reset ovsdb trx before run the second etcd trx attempt

### DIFF
--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -385,6 +385,9 @@ Loop:
 	if err != nil {
 		if err.Error() == E_CONCURRENCY_ERROR {
 			// let's try again
+			txn.etcdTrx.Clear()
+			txn.response.Result = make([]libovsdb.OperationResult, len(txn.request.Operations))
+			txn.localCache = &localCache{}
 			err = processOperations()
 			if err != nil {
 				return -1, err


### PR DESCRIPTION
When we get the concurrency error, we run another attempt. This PR fixes the ovsdb transaction reset before running this second attempt.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>