### PR TITLE
reimplementation of the setsDifference function

### DIFF
--- a/pkg/ovsdb/monitor.go
+++ b/pkg/ovsdb/monitor.go
@@ -658,28 +658,24 @@ func (u *updater) prepareRow(value []byte) (map[string]interface{}, string, erro
 	return data, uuid, nil
 }
 
+// setsDifference returns a delta between 2 sets. It assumes that there is no duplicate elements in the sets.
 func setsDifference(set1 libovsdb.OvsSet, set2 libovsdb.OvsSet) libovsdb.OvsSet {
 	var diff libovsdb.OvsSet
+	m := make(map[interface{}]bool)
 
-	// Loop two times, first to find elements from set1 which are not in set2,
-	// second loop to find elements from set2 which are not in set1
-	for i := 0; i < 2; i++ {
-		for _, s1 := range set1.GoSet {
-			found := false
-			for _, s2 := range set2.GoSet {
-				if s1 == s2 {
-					found = true
-					break
-				}
-			}
-			if !found {
-				diff.GoSet = append(diff.GoSet, s1)
-			}
+	for _, item := range set2.GoSet {
+		m[item] = true
+	}
+
+	for _, item := range set1.GoSet {
+		if _, ok := m[item]; !ok {
+			diff.GoSet = append(diff.GoSet, item)
+		} else {
+			delete(m, item)
 		}
-		// Swap the sets, only if it was the first loop
-		if i == 0 {
-			set1, set2 = set2, set1
-		}
+	}
+	for item, _ := range m {
+		diff.GoSet = append(diff.GoSet, item)
 	}
 	return diff
 }

--- a/pkg/ovsdb/monitor_test.go
+++ b/pkg/ovsdb/monitor_test.go
@@ -947,6 +947,7 @@ func TestSetsDifferenceSubset2(t *testing.T) {
 	assert.Equal(t, expectDiff, diff)
 }
 
+// the test violates missing duplication elements, but it passes due to duplications are in the second test only.
 func TestSetsDifferenceDifferentSets(t *testing.T) {
 	set1 := libovsdb.OvsSet{GoSet: []interface{}{"one", "two", "four"}}
 	set2 := libovsdb.OvsSet{GoSet: []interface{}{"two", "three", "two"}}


### PR DESCRIPTION
ovsdb-etcd profiling showed that the setsDifference  function uses a lot of CPU. This PR reimplements it to provide a more efficient implementation.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>