### PR TITLE
SSL support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/cmd/client/client
 pkg/cmd/server/server
 dist/images/ovndb-raft-functions.sh
 dist/images/ovnkube.sh
+tests/e2e/keys/

--- a/pkg/cmd/ssl_utils/ssl-util.go
+++ b/pkg/cmd/ssl_utils/ssl-util.go
@@ -1,0 +1,166 @@
+package ssl_utils
+
+import (
+	"crypto/tls"
+	"errors"
+	"flag"
+	"fmt"
+	"reflect"
+)
+
+var SslVersion = flag.String("ssl-version", "", "choose ssl version to use")
+var SslCipherSuite = flag.String("ssl-cipher-suite", "", "choose ssl cipher suite to use")
+
+const (
+	VersionTLS10 = "VersionTLS10"
+	VersionTLS11 = "VersionTLS11"
+	VersionTLS12 = "VersionTLS12"
+	VersionTLS13 = "VersionTLS13"
+)
+
+var (
+	//supportedUpToTLS12 = []uint16{VersionTLS10, VersionTLS11, VersionTLS12}
+	//supportedOnlyTLS12 = []uint16{VersionTLS12}
+	supportedOnlyTLS13 = []uint16{tls.VersionTLS13}
+)
+
+type CipherSuite tls.CipherSuite
+
+type Version struct {
+	Name string
+	ID   uint16
+}
+
+func (version Version) String() string {
+	return fmt.Sprintf("'%s'", version.Name)
+}
+
+func (cipherSuite CipherSuite) String() string {
+	return fmt.Sprintf("'%s'", cipherSuite.Name)
+}
+
+func AddSslToConfig(conf *tls.Config, sslCipherSuitesName string, sslVersionName string) error {
+	if conf == nil {
+		return errors.New("conf is an empty pointer")
+	}
+	var cipherSuite CipherSuite
+	var version Version
+	var err error
+	if sslCipherSuitesName != "" {
+		cipherSuite, err = GetCipherSuite(sslCipherSuitesName)
+		if err != nil {
+			return err
+		}
+	}
+	if sslVersionName != "" {
+		version, err = GetVersion(sslVersionName)
+		if err != nil {
+			return err
+		}
+	}
+	if sslCipherSuitesName != "" && sslVersionName != "" {
+		err = assertCipherSuiteSupportsSSLVersion(cipherSuite, version)
+		if err != nil {
+			return err
+		}
+	}
+	if sslCipherSuitesName != "" {
+		conf.CipherSuites = []uint16{cipherSuite.ID}
+	}
+	if sslVersionName != "" {
+		conf.MaxVersion = version.ID
+		conf.MinVersion = version.ID
+	}
+	return nil
+}
+
+func assertCipherSuiteSupportsSSLVersion(cipherSuite CipherSuite, version Version) error {
+	if cipherSuiteSupportsVersion(cipherSuite, version) {
+		return nil
+	}
+	return errors.New(fmt.Sprintf("cipher suite %s not support ssl version %s. available ssl versions for this cipher suite:%s", cipherSuite, version, getVersionsSupportedByCipherSuite(cipherSuite)))
+}
+
+func getSupportedCipherSuites() []CipherSuite {
+	var res []CipherSuite
+	for _, suit := range tls.CipherSuites() {
+		res = append(res, CipherSuite(*suit))
+	}
+	return res
+}
+
+func getSupportedVersions() []Version {
+	return []Version{
+		{VersionTLS10, tls.VersionTLS10},
+		{VersionTLS11, tls.VersionTLS11},
+		{VersionTLS12, tls.VersionTLS12},
+		{VersionTLS13, tls.VersionTLS13},
+	}
+}
+
+func GetCipherSuite(name string) (CipherSuite, error) {
+	for _, suite := range getSupportedCipherSuites() {
+		if suite.Name == name {
+			return suite, nil
+		}
+	}
+	return CipherSuite{}, errors.New(fmt.Sprintf("not supported cipher suite. available cipher suites:%s", getSupportedCipherSuites()))
+}
+
+func GetVersion(condition interface{}) (Version, error) {
+	for _, version := range getSupportedVersions() {
+		switch condition := condition.(type) {
+		case string:
+			if version.Name == condition {
+				return version, nil
+			}
+		case uint16:
+			if version.ID == condition {
+				return version, nil
+			}
+		default:
+			return Version{}, errors.New(fmt.Sprintf("not supported condition type for GetVersion %T", condition))
+		}
+	}
+	return Version{}, errors.New(fmt.Sprintf("not supported ssl version. available ssl versions:%s", getSupportedVersions()))
+}
+
+func getCipherSuitesFilteredByCond(cond func(CipherSuite) bool) []CipherSuite {
+	var res []CipherSuite
+	for _, suite := range getSupportedCipherSuites() {
+		if cond(suite) {
+			res = append(res, suite)
+		}
+	}
+	return res
+}
+
+func GetCipherSuitesSupportedOnlyTLS3() []CipherSuite {
+	return getCipherSuitesFilteredByCond(func(cs CipherSuite) bool { return reflect.DeepEqual(cs.SupportedVersions, supportedOnlyTLS13) })
+}
+
+func GetVersionsFilteredByCond(cond func(Version) bool) []Version {
+	var res []Version
+	for _, version := range getSupportedVersions() {
+		if cond(version) {
+			res = append(res, version)
+		}
+	}
+	return res
+}
+
+func getVersionsSupportedByCipherSuite(cipherSuite CipherSuite) []Version {
+	cond := func(version Version) bool {
+		return cipherSuiteSupportsVersion(cipherSuite, version)
+	}
+	return GetVersionsFilteredByCond(cond)
+}
+
+func cipherSuiteSupportsVersion(cipherSuite CipherSuite, version Version) bool {
+	for _, supportedCiphesuiteVersionID := range cipherSuite.SupportedVersions {
+		if supportedCiphesuiteVersionID == version.ID {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -1,15 +1,21 @@
 ROOT_DIR := ../..
 
 TCP_ADDRESS = :12345
+FULL_TCP_ADDRESS = 127.0.0.1:12345
 UNIX_ADDRESS = /tmp/ovnnb_db.db
 
 ETCD_NAME := ovsdb
 
 DATABASE-PREFIX := ovsdb
-SERVICE-NAME :=nb
+SERVICE-NAME := nb
 SCHEMA-FILE := ovn-nb.ovsschema
-LOAD-SERVER-DATA=TRUE := true
+LOAD-SERVER-DATA :=true
 PID-FILE :=/tmp/nb-ovsdb.pid
+#SSL-PRIVKEY :=""
+#SSL-CERT :=""
+KEYS-ROOT-DIR-NAME := ./keys
+SERVER-KEYS-DIR-NAME := $(KEYS-ROOT-DIR-NAME)/server
+CLIENT-KEYS-DIR-NAME := $(KEYS-ROOT-DIR-NAME)/client
 
 .PHONY: etcd
 etcd:
@@ -22,13 +28,47 @@ SERVER_FILES := \
 	$(ROOT_DIR)/pkg/cmd/server/testdata.go
 
 SERVER_ARGS := \
-		-tcp-address $(TCP_ADDRESS) \
-		-unix-address $(UNIX_ADDRESS) \
-		-schema-basedir $(ROOT_DIR)/schemas \
-		-database-prefix $(DATABASE-PREFIX) \
-		-service-name $(SERVICE-NAME) \
-		-schema-file $(SCHEMA-FILE) \
-		-pid-file $(PID-FILE)
+		--tcp-address=$(TCP_ADDRESS) \
+		--unix-address=$(UNIX_ADDRESS) \
+		--schema-basedir=$(ROOT_DIR)/schemas \
+		--database-prefix=$(DATABASE-PREFIX) \
+		--service-name=$(SERVICE-NAME) \
+		--schema-file=$(SCHEMA-FILE) \
+		--load-server-data=$(LOAD-SERVER-DATA) \
+		--pid-file=$(PID-FILE) \
+
+CLIENT_ARGS := \
+		--server=$(TCP_ADDRESS)
+
+CLIENT_FILES := \
+	$(ROOT_DIR)/pkg/cmd/client/client.go
+
+define generate_private_public_keys_pair
+	$(call generate_private_key,$(1))
+	$(call generate_public_key,$(1))
+endef
+
+define generate_private_key
+	openssl genrsa -out $(1).key 2048
+endef
+
+define generate_public_key
+	openssl req -new -x509 -sha256 -key $(1).key -out $(1).pem -days 3650 -subj '/C=IL/ST=HAIFA/L=HAIFA/CN=www.ibm.com'
+endef
+
+.PHONY: remove-all-keys
+remove-all-keys: 
+	rm -rf $(KEYS-ROOT-DIR-NAME)
+
+.PHONY: create-ssl-server-keys
+create-ssl-server-keys: 
+	mkdir -p $(SERVER-KEYS-DIR-NAME)
+	$(call generate_private_public_keys_pair,$(SERVER-KEYS-DIR-NAME)/server)
+.PHONY: create-ssl-client-keys
+
+create-ssl-client-keys: 
+	mkdir -p $(CLIENT-KEYS-DIR-NAME)
+	$(call generate_private_public_keys_pair,$(CLIENT-KEYS-DIR-NAME)/client)
 
 .PHONY: dbg-server
 dbg-server: 
@@ -38,11 +78,14 @@ dbg-server:
 server: 
 	go run $(SERVER_FILES) $(SERVER_ARGS)
 
-CLIENT_ARGS := \
-		-server $(TCP_ADDRESS)
+.PHONY: ssl-server
+ssl-server: 
+	if [ ! -d "$(SERVER-KEYS-DIR-NAME)" ]; then $(MAKE) create-ssl-server-keys; fi
+	$(eval SSL-PRIVKEY:=$(SERVER-KEYS-DIR-NAME)/server.key)
+	$(eval SSL-CERT:=$(SERVER-KEYS-DIR-NAME)/server.pem)
+	$(eval SERVER_ARGS := $(SERVER_ARGS) --ssl-privkey=$(SSL-PRIVKEY) --ssl-cert=$(SSL-CERT))
+	go run $(SERVER_FILES) $(SERVER_ARGS)
 
-CLIENT_FILES := \
-	$(ROOT_DIR)/pkg/cmd/client/client.go
 
 .PHONY: dbg-client
 dbg-client:
@@ -50,7 +93,20 @@ dbg-client:
 
 .PHONY: client
 client:
+	$(eval CLIENT_ARGS := $(CLIENT_ARGS) --use-ssl=false)
 	go run $(CLIENT_FILES) $(CLIENT_ARGS)
+
+.PHONY: ssl-client
+ssl-client: 
+	$(eval CLIENT_ARGS := $(CLIENT_ARGS) --use-ssl=true)
+	go run $(CLIENT_FILES) $(CLIENT_ARGS)
+
+.PHONY: ssl-ovsdb-client
+ssl-ovsdb-client: 
+	if [ ! -d "$(CLIENT-KEYS-DIR-NAME)" ]; then $(MAKE) create-ssl-client-keys; fi
+	$(eval SSL-PRIVKEY:=$(CLIENT-KEYS-DIR-NAME)/client.key)
+	$(eval SSL-CERT:=$(CLIENT-KEYS-DIR-NAME)/client.pem)
+	ovsdb-client list-dbs ssl:$(FULL_TCP_ADDRESS) --ca-cert=none --private-key=$(SSL-PRIVKEY) --certificate=$(SSL-CERT)
 
 INSTALL_TOOLS += /usr/bin/pv
 /usr/bin/pv:


### PR DESCRIPTION
This PR adds ssl support for the client and the server.
using `tests/e2e/Makefile` one can:
1. create and delete ssl keys for the server and the client.
2. deploy client and server with or without ssl.
3. call ovsdb-client with ssl.
## note about TLS13
client cannot configure specific cipher suite when using TLS3.(as seen on `tls` package)
```go
type Config struct {
.
.
.
// CipherSuites is a list of enabled TLS 1.0–1.2 cipher suites. The order of
// the list is ignored. Note that TLS 1.3 ciphersuites are not configurable.
//
// If CipherSuites is nil, a safe default list is used. The default cipher
// suites might change over time.
CipherSuites []uint16
.
.
.
}
```
## examples
the following commands should be executed from the root directory.
### create ssl keys
make keys for the client and the server
```bash
make -C tests/e2e/ create-ssl-client-keys
make -C tests/e2e/ create-ssl-server-keys
```
### deploy server and client from makefile
create ssl server and ssl client
```bash
make -C tests/e2e/ ssl-client
make -C tests/e2e/ ssl-server
```
create ssl ovsdb client
```bash
make -C tests/e2e/ ssl-ovsdb-client
```
### deploy server and client  with specific cipher suite and ssl version
the following commands should be executed from the root directory.
create server
```bash
go run ./pkg/cmd/server/server.go --tcp-address=:12345 --unix-address=/tmp/ovnnb_db.db --schema-basedir=./schemas --database-prefix=ovsdb --service-name=nb --schema-file=ovn-nb.ovsschema --load-server-data=true --pid-file=/tmp/nb-ovsdb.pid  --ssl-privkey=./tests/e2e/keys/server/server.key --ssl-cert=./tests/e2e/keys/server/server.pem --ssl-version=VersionTLS12 --ssl-cipher-suite=TLS_RSA_WITH_3DES_EDE_CBC_SHA
```
create client
```bash
go run pkg/cmd/client/client.go -server=127.0.0.1:12345 -use-ssl=true --ssl-version=VersionTLS12 --ssl-cipher-suite=TLS_RSA_WITH_3DES_EDE_CBC_SHA
```

### available cipher suites
```
'TLS_RSA_WITH_3DES_EDE_CBC_SHA'
'TLS_RSA_WITH_AES_128_CBC_SHA'
'TLS_RSA_WITH_AES_256_CBC_SHA'
'TLS_RSA_WITH_AES_128_GCM_SHA256'
'TLS_RSA_WITH_AES_256_GCM_SHA384'
'TLS_AES_128_GCM_SHA256'
'TLS_AES_256_GCM_SHA384'
'TLS_CHACHA20_POLY1305_SHA256'
'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA'
'TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA'
'TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA'
'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA'
'TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA'
'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256'
'TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
'TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
'TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256'
'TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256'
```

### available ssl versions
```
'VersionTLS10'
'VersionTLS11'
'VersionTLS12'
'VersionTLS13'
```