### PR TITLE
Common prepare row for all monitors

### DIFF
--- a/pkg/libovsdb/row.go
+++ b/pkg/libovsdb/row.go
@@ -1,6 +1,9 @@
 package libovsdb
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // Row is a table Row according to RFC7047
 type Row struct {
@@ -20,6 +23,22 @@ func (r *Row) UnmarshalJSON(b []byte) (err error) {
 		r.Fields[key] = val
 	}
 	return err
+}
+
+func (r *Row) GetUUID() (*UUID, error) {
+	uuidInt, ok := r.Fields[COL_UUID]
+	if !ok {
+		return nil, fmt.Errorf("row doesn't contain %s", COL_UUID)
+	}
+	uuid, ok := uuidInt.(UUID)
+	if !ok {
+		return nil, fmt.Errorf("wrong uuid type %T %v", uuidInt, uuidInt)
+	}
+	return &uuid, nil
+}
+
+func (r *Row) deleteUUID() {
+	delete(r.Fields, COL_UUID)
 }
 
 // ResultRow is an properly unmarshalled row returned by Transact

--- a/pkg/ovsdb/database.go
+++ b/pkg/ovsdb/database.go
@@ -234,31 +234,6 @@ type Event struct {
 	PrevKv *EventKeyValue `json:"prev_kv"`
 }
 
-func NewEvent(ev *clientv3.Event) Event {
-	return Event{
-		Type:   string(ev.Type),
-		Kv:     NewEventKeyValue(ev.Kv),
-		PrevKv: NewEventKeyValue(ev.PrevKv),
-	}
-}
-
-type EventList []Event
-
-func NewEventList(events []*clientv3.Event) EventList {
-	printable := EventList{}
-	for _, ev := range events {
-		if ev != nil {
-			printable = append(printable, NewEvent(ev))
-		}
-	}
-	return printable
-}
-
-func (evList EventList) String() string {
-	b, _ := json.Marshal(evList)
-	return string(b)
-}
-
 type DatabaseMock struct {
 	Response interface{}
 	Error    error


### PR DESCRIPTION
All monitors have to prepare a row (unmarshal row data from JSON to goLang object). This PR implements shared prepareRow for all monitors.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>