### PR TITLE
add select single row by index

### DIFF
--- a/pkg/libovsdb/notation.go
+++ b/pkg/libovsdb/notation.go
@@ -56,7 +56,7 @@ func (o Operation) String() string {
 }
 
 // MarshalJSON marshalls 'Operation' to a byte array
-// For 'select' operations, we dont omit the 'Where' field
+// For 'select' operations, we don't omit the 'Where' field
 // to allow selecting all rows of a table
 func (o Operation) MarshalJSON() ([]byte, error) {
 	type OpAlias Operation

--- a/pkg/ovsdb/condition_test.go
+++ b/pkg/ovsdb/condition_test.go
@@ -19,7 +19,7 @@ func TestConditionUUID(t *testing.T) {
 	cond := []interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}
 	tableSchema, ok := testSchemaSimple.Tables[table]
 	assert.True(t, ok)
-	pCondition, err := NewCondition(&tableSchema, nil, cond, klogr.New())
+	pCondition, err := NewCondition(&tableSchema, cond, klogr.New())
 	assert.Nil(t, err)
 	condition := *pCondition
 	uuidStr, err := condition.getUUIDIfExists()

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -83,7 +83,6 @@ func (ch *Handler) Transact(ctx context.Context, params []interface{}) (interfac
 	ch.mu.RLock()
 	monitor, thereIsMonitor := ch.monitors[txn.request.DBName]
 	ch.mu.RUnlock()
-	// temporary solution to provide consistency
 	err = txn.lockTables()
 	if err != nil {
 		return nil, err

--- a/pkg/ovsdb/monitor.go
+++ b/pkg/ovsdb/monitor.go
@@ -658,7 +658,7 @@ func unmarshalData(data []byte) (map[string]interface{}, error) {
 func (u *updater) isRowAppearOnWhere(data map[string]interface{}) (bool, error) {
 	checkCondition := func(condition []interface{}) (bool, error) {
 		log := klogr.New() // TODO: propagate real logger instead of this generic one
-		res, err := NewCondition(u.tableSchema, namedUUIDResolver{}, condition, log)
+		res, err := NewCondition(u.tableSchema, condition, log)
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Some of OVNk transaction requests have "Where" entry with selection of a single row by "indexed columns". In this case, we don't need to lock the entire table, and can operate over a specific key only.

The PR adds this optimization. 
 
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>