### PR TITLE
Put comments into a separate key-tree

### DIFF
--- a/pkg/common/key.go
+++ b/pkg/common/key.go
@@ -9,8 +9,8 @@ import (
 
 const (
 	KEY_DELIMITER = "/"
-	LOCKS         = "_locks"
-	COMMENTS      = "_comments"
+	LOCKS         = "locks"
+	COMMENTS      = "comments"
 	INTERNAL_DB   = "_"
 )
 
@@ -104,8 +104,8 @@ func NewDataKey(dbName, tableName, uuid string) Key {
 
 // Returns a new Comment key. If the given commentID is an empty string, the return key will point to the entire
 // comments table, and this function call is equals to call `NewCommentTableKey`.
-func NewCommentKey(dbName, commentID string) Key {
-	return NewDataKey(dbName, COMMENTS, commentID)
+func NewCommentKey(commentID string) Key {
+	return NewDataKey(INTERNAL_DB, COMMENTS, commentID)
 }
 
 // Returns a new Lock key. If the given lockID is an empty string, the return key will point to the entire
@@ -120,8 +120,8 @@ func NewTableKey(dbName, tableName string) Key {
 }
 
 // Helper function, which returns a key to the Comments table
-func NewCommentTableKey(dbName string) Key {
-	return NewCommentKey(dbName, "")
+func NewCommentTableKey() Key {
+	return NewCommentKey("")
 }
 
 // Helper function, which returns a key to the Locks table

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -1246,7 +1246,7 @@ func (txn *Transaction) doAbort(ovsOp *libovsdb.Operation, ovsResult *libovsdb.O
 /* comment */
 func (txn *Transaction) doComment(ovsOp *libovsdb.Operation, ovsResult *libovsdb.OperationResult) (error, string) {
 	timestamp := time.Now().Format(time.RFC3339)
-	key := common.NewCommentKey(txn.request.DBName, timestamp)
+	key := common.NewCommentKey(timestamp)
 	comment := *ovsOp.Comment
 	etcdOp := clientv3.OpPut(key.String(), comment)
 	txn.etcdTrx.appendThen(etcdOp)

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -286,11 +286,11 @@ func testEtcdPut(t *testing.T, dbname, table string, uuid string, row map[string
 	assert.Nil(t, err)
 }
 
-func testEtcdGetComment(t *testing.T, dbName, comment string) {
+func testEtcdGetComment(t *testing.T, comment string) {
 	cli, err := testEtcdNewCli()
 	assert.Nil(t, err)
 	ctx := context.TODO()
-	key := common.NewCommentTableKey(dbName)
+	key := common.NewCommentTableKey()
 	response, err := cli.Get(ctx, key.String(), clientv3.WithPrefix(), clientv3.WithSort(clientv3.SortByKey, clientv3.SortAscend))
 	assert.Nil(t, err)
 	for _, kv := range response.Kvs {
@@ -2184,7 +2184,7 @@ func TestTransactSelectAndComment(t *testing.T) {
 	assert.EqualValues(t, 3, row["key2"])
 
 	validateEmptyResult(t, resp, 2, 1)
-	testEtcdGetComment(t, req.DBName, comment)
+	testEtcdGetComment(t, comment)
 }
 
 func TestTransactComment(t *testing.T) {
@@ -2201,7 +2201,7 @@ func TestTransactComment(t *testing.T) {
 	testEtcdCleanup(t)
 	resp := testTransact(t, req, testSchemaSimple, -1)
 	assert.Nil(t, resp.Error)
-	testEtcdGetComment(t, req.DBName, comment)
+	testEtcdGetComment(t, comment)
 }
 
 func TestTransactAssert(t *testing.T) {


### PR DESCRIPTION
Comments cannot be parsed into libovsdb.Row, and they should not be propagated to monitor, and transaction cache, so we put them into a separate tree. (locks were there before)

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>