### PR TITLE
Server error

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -165,6 +165,10 @@ func main() {
 	loop := func(lst net.Listener) {
 		for {
 			conn, err := lst.Accept()
+			if err != nil {
+				log.Error(err, "Accept returned")
+				os.Exit(1)
+			}
 			ch := channel.RawJSON(conn, conn)
 			go func() {
 				ctxt, cancel := context.WithCancel(context.Background())
@@ -176,9 +180,6 @@ func main() {
 				srv.Start(ch)
 				stat := srv.WaitStatus()
 				log.V(5).Info("connection", "from", conn.RemoteAddr(), "stopped", stat.Stopped(), "closed", stat.Closed(), "success", stat.Success(), "err", stat.Err)
-				if stat.Err != nil {
-					log.Error(err, "Server exit")
-				}
 				handler.Cleanup()
 				cancel()
 			}()


### PR DESCRIPTION
When a client closed its connection to the ovsdb-etcd server, the latter printed a Server error message, that was misleading. 
The PR changed this behaviour to print an info message instead of error.

Signed-off-by: Alexey Roytman roytman@il.ibm.com