### PR TITLE
Store _Server/Databases data locally

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -98,7 +98,6 @@ func main() {
 		}
 	}
 
-	// several OVSDB deployments can share the same etcd, but for rest of the work, we don't have to separate
 	// databasePrefix and serviceName.
 	common.SetPrefix(*databasePrefix + common.KEY_DELIMITER + *serviceName)
 
@@ -119,16 +118,14 @@ func main() {
 	}()
 
 	db, _ := ovsdb.NewDatabaseEtcd(cli, log)
-
 	err = db.AddSchema(path.Join(*schemaBasedir, "_server.ovsschema"))
 	if err != nil {
-		log.Error(err, "failed to add schema")
+		log.Error(err, "failed to add _server schema")
 		os.Exit(1)
 	}
-
 	err = db.AddSchema(path.Join(*schemaBasedir, *schemaFile))
 	if err != nil {
-		log.Error(err, "failed to add schema")
+		log.Error(err, "failed to add schema", "schema file", *schemaFile)
 		os.Exit(1)
 	}
 
@@ -153,7 +150,6 @@ func main() {
 		signal.Stop(exitCh)
 		cancel()
 	}()
-
 	servOptions := &jrpc2.ServerOptions{
 		Concurrency: *maxTasks,
 		Metrics:     metrics.New(),

--- a/pkg/ovsdb/cache.go
+++ b/pkg/ovsdb/cache.go
@@ -33,6 +33,10 @@ func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client, log
 		return errors.New("Duplicate DatabaseCache: " + dbName)
 	}
 	dbCache := databaseCache{dbCache: map[string]tableCache{}, log: log}
+	(*c)[dbName] = &dbCache
+	if dbName == INT_SERVER {
+		return nil
+	}
 	ctxt, cancel := context.WithCancel(context.Background())
 	dbCache.cancel = cancel
 	key := common.NewDBPrefixKey(dbName)
@@ -45,7 +49,7 @@ func (c *cache) addDatabaseCache(dbName string, etcdClient *clientv3.Client, log
 		clientv3.WithPrefix(),
 		clientv3.WithCreatedNotify(),
 		clientv3.WithPrevKV())
-	(*c)[dbName] = &dbCache
+
 	err = dbCache.putEtcdKV(resp.Kvs)
 	if err != nil {
 		log.Error(err, "putEtcdKV")

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -487,13 +487,16 @@ func (ch *Handler) addMonitor(params []interface{}, notificationType ovsjson.Upd
 		updatersKeys = append(updatersKeys, key)
 	}
 	log := ch.log.WithValues("jsonValue", cmpr.JsonValue)
-	monitor, ok := ch.monitors[cmpr.DatabaseName]
-	if !ok {
-		monitor = ch.db.CreateMonitor(cmpr.DatabaseName, ch, log)
-		monitor.start()
-		ch.monitors[cmpr.DatabaseName] = monitor
+	if cmpr.DatabaseName != INT_SERVER {
+		monitor, ok := ch.monitors[cmpr.DatabaseName]
+		if !ok {
+			monitor = ch.db.CreateMonitor(cmpr.DatabaseName, ch, log)
+			monitor.start()
+			ch.monitors[cmpr.DatabaseName] = monitor
+		}
+		monitor.addUpdaters(updatersMap)
 	}
-	monitor.addUpdaters(updatersMap)
+
 	ch.handlerMonitorData[jsonValueString] = handlerMonitorData{
 		log:               log,
 		dataBaseName:      cmpr.DatabaseName,

--- a/pkg/ovsdb/service.go
+++ b/pkg/ovsdb/service.go
@@ -3,8 +3,8 @@ package ovsdb
 import (
 	"context"
 	"fmt"
+
 	"github.com/google/uuid"
-	"github.com/ibm/ovsdb-etcd/pkg/common"
 	"k8s.io/klog/v2"
 
 	"github.com/ibm/ovsdb-etcd/pkg/ovsjson"
@@ -217,17 +217,14 @@ type Service struct {
 
 func (s *Service) ListDbs(ctx context.Context, param interface{}) ([]string, error) {
 	klog.V(5).Info("ListDbs request")
-	resp, err := s.db.GetKeyData(common.NewTableKey(INT_SERVER, INT_DATABASES), true)
+	dbCache, err := s.db.GetDBCache(INT_SERVER)
 	if err != nil {
 		return nil, err
 	}
-	dbs := make([]string, 0, len(resp.Kvs))
-	for _, kv := range resp.Kvs {
-		key, err := common.ParseKey(string(kv.Key))
-		if err != nil {
-			return nil, err
-		}
-		dbs = append(dbs, key.UUID)
+	tCache := dbCache.getTable(INT_DATABASES)
+	dbs := make([]string, 0, len(*tCache))
+	for key, _ := range *tCache {
+		dbs = append(dbs, key)
 	}
 	klog.V(5).Infof("ListDbs returned %v", dbs)
 	return dbs, nil


### PR DESCRIPTION
Data in the _Server database is per-server and should not be stored in etcd and shared between all servers. This PR fixes it.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>