### PR TITLE
Implement clusterID

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -115,19 +115,6 @@ func main() {
 		err := cli.Close()
 		log.Error(err, "cli close")
 	}()
-
-	db, _ := ovsdb.NewDatabaseEtcd(cli, log)
-	err = db.AddSchema(path.Join(*schemaBasedir, "_server.ovsschema"))
-	if err != nil {
-		log.Error(err, "failed to add _server schema")
-		os.Exit(1)
-	}
-	err = db.AddSchema(path.Join(*schemaBasedir, *schemaFile))
-	if err != nil {
-		log.Error(err, "failed to add schema", "schema file", *schemaFile)
-		os.Exit(1)
-	}
-
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
 	exitCh := make(chan os.Signal, 1)
@@ -140,6 +127,20 @@ func main() {
 		signal.Stop(exitCh)
 		cancel()
 	}()
+
+	db, _ := ovsdb.NewDatabaseEtcd(cli, log)
+	err = db.AddSchema(path.Join(*schemaBasedir, "_server.ovsschema"))
+	if err != nil {
+		log.Error(err, "failed to add _server schema")
+		os.Exit(1)
+	}
+
+	err = db.AddSchema(path.Join(*schemaBasedir, *schemaFile))
+	if err != nil {
+		log.Error(err, "failed to add schema", "schema file", *schemaFile)
+		os.Exit(1)
+	}
+
 	servOptions := &jrpc2.ServerOptions{
 		Concurrency: *maxTasks,
 		Metrics:     metrics.New(),

--- a/pkg/ovsdb/service.go
+++ b/pkg/ovsdb/service.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
 	"k8s.io/klog/v2"
 
 	"github.com/ibm/ovsdb-etcd/pkg/ovsjson"
@@ -206,8 +205,9 @@ type Servicer interface {
 }
 
 const (
-	INT_SERVER    = "_Server"
-	INT_DATABASES = "Database"
+	INT_SERVER     = "_Server"
+	INT_DATABASES  = "Database"
+	INT_ClusterIDs = "CID"
 )
 
 type Service struct {
@@ -254,7 +254,7 @@ func (s *Service) GetSchema(ctx context.Context, param interface{}) (interface{}
 
 func (s *Service) GetServerId(ctx context.Context) string {
 	klog.V(5).Infof("GetServerId request")
-	return s.uuid
+	return s.db.GetServerID()
 }
 
 func (s *Service) Convert(ctx context.Context, param interface{}) (interface{}, error) {
@@ -264,7 +264,6 @@ func (s *Service) Convert(ctx context.Context, param interface{}) (interface{}, 
 
 func NewService(db Databaser) *Service {
 	return &Service{
-		db:   db,
-		uuid: uuid.NewString(),
+		db: db,
 	}
 }


### PR DESCRIPTION
Some of the entries in the _Server database were not correctly implemented. 
They are:

-  `cid` - the cluster id and it should be shared between all servers
- `sid` - the given server id, which should be returned by `get_server_id` request

This PR fixes these issues.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>