### PR TITLE
Return back loadServerDataFlag flag for backward compatability

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -42,6 +42,8 @@ var (
 	cpuProfile       = flag.String("cpu-profile", "", "write cpu profile to file")
 	keepAliveTime    = flag.Duration("keepalive-time", -1*time.Second, "keepalive time for the etcd client connection")
 	keepAliveTimeout = flag.Duration("keepalive-timeout", -1*time.Second, "keepalive timeout for the etcd client connection")
+	// returned back for backward compatability with executable scripts, wil be removed later
+	loadServerDataFlag = flag.Bool("load-server-data", false, "load-server-data")
 )
 
 var GitCommit string


### PR DESCRIPTION
Some of the executable scripts, e.g. ovn heater use the `loadServerDataFlag` flag, we temporarily returned the flag here to allow the scripts to run.
Later, after updating the scripts, the flag will be removed 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>