### PR TITLE
Replace Locks to RLocks to the read from cache operations

### DIFF
--- a/pkg/ovsdb/cache.go
+++ b/pkg/ovsdb/cache.go
@@ -15,7 +15,7 @@ import (
 type cache map[string]*databaseCache
 
 type databaseCache struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	dbCache map[string]tableCache
 	// cancel function to close the etcdTrx watcher
 	cancel context.CancelFunc

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -542,8 +542,8 @@ func (ch *Handler) getMonitoredData(dbName string, updatersMap Key2Updaters) (ov
 		return nil, err
 	}
 	returnData := ovsjson.TableUpdates{}
-	dbCache.mu.Lock()
-	defer dbCache.mu.Unlock()
+	dbCache.mu.RLock()
+	defer dbCache.mu.RUnlock()
 	for tableKey, updaters := range updatersMap {
 		if len(updaters) == 0 {
 			// nothing to update

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -358,8 +358,8 @@ Loop:
 	}
 
 	processOperations := func() error {
-		txn.cache.mu.Lock()
-		defer txn.cache.mu.Unlock()
+		txn.cache.mu.RLock()
+		defer txn.cache.mu.RUnlock()
 		// insert name-uuid preprocessing
 		for i, ovsOp := range txn.request.Operations {
 			if ovsOp.Op == libovsdb.OperationInsert {


### PR DESCRIPTION
Replace Locks to Rlocks to the read-only operations from the cache.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>