### PR TITLE
Rename constants according to GoLang convention

### DIFF
--- a/pkg/libovsdb/row.go
+++ b/pkg/libovsdb/row.go
@@ -26,9 +26,9 @@ func (r *Row) UnmarshalJSON(b []byte) (err error) {
 }
 
 func (r *Row) GetUUID() (*UUID, error) {
-	uuidInt, ok := r.Fields[COL_UUID]
+	uuidInt, ok := r.Fields[ColUuid]
 	if !ok {
-		return nil, fmt.Errorf("row doesn't contain %s", COL_UUID)
+		return nil, fmt.Errorf("row doesn't contain %s", ColUuid)
 	}
 	uuid, ok := uuidInt.(UUID)
 	if !ok {
@@ -38,7 +38,7 @@ func (r *Row) GetUUID() (*UUID, error) {
 }
 
 func (r *Row) deleteUUID() {
-	delete(r.Fields, COL_UUID)
+	delete(r.Fields, ColUuid)
 }
 
 // ResultRow is an properly unmarshalled row returned by Transact

--- a/pkg/libovsdb/schema.go
+++ b/pkg/libovsdb/schema.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	COL_UUID    = "_uuid"
+	ColUuid     = "_uuid"
 	COL_VERSION = "_version"
 )
 
@@ -148,7 +148,7 @@ func (tableSchema *TableSchema) AddInternalColumns() {
 	tableSchema.Columns[COL_VERSION] = &ColumnSchema{
 		Type: TypeUUID,
 	}
-	tableSchema.Columns[COL_UUID] = &ColumnSchema{
+	tableSchema.Columns[ColUuid] = &ColumnSchema{
 		Type: TypeUUID,
 	}
 }
@@ -703,7 +703,7 @@ func (tableSchema *TableSchema) Unmarshal(row *map[string]interface{}) error {
 			var to interface{}
 			var err error
 			switch column {
-			case COL_UUID, COL_VERSION:
+			case ColUuid, COL_VERSION:
 				to, err = UnmarshalUUID(value)
 			default:
 				to, err = columnSchema.Unmarshal(value)

--- a/pkg/ovsdb/cache_test.go
+++ b/pkg/ovsdb/cache_test.go
@@ -86,7 +86,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	// table1
 	t1UUID := uuid.NewString()
 	t1ovsUUID := libovsdb.UUID{GoUUID: t1UUID}
-	val[libovsdb.COL_UUID] = t1ovsUUID
+	val[libovsdb.ColUuid] = t1ovsUUID
 	val["name"] = "t1Row"
 	key1 := common.NewDataKey("gc", "table1", t1UUID)
 	buf1, err := json.Marshal(val)
@@ -98,7 +98,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	// root table
 	rootUUID := uuid.NewString()
 	rootOvsUUID := libovsdb.UUID{GoUUID: rootUUID}
-	val[libovsdb.COL_UUID] = rootOvsUUID
+	val[libovsdb.ColUuid] = rootOvsUUID
 	val["name"] = "rootRow"
 	val["refUUID"] = t1ovsUUID
 	keyR := common.NewDataKey("gc", "rootTable", rootUUID)
@@ -171,7 +171,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	// table1
 	t1UUID := uuid.NewString()
 	t1ovsUUID := libovsdb.UUID{GoUUID: t1UUID}
-	val[libovsdb.COL_UUID] = t1ovsUUID
+	val[libovsdb.ColUuid] = t1ovsUUID
 	val["name"] = "t1Row"
 	key1 := common.NewDataKey("gc", "table1", t1UUID)
 	buf1, err := json.Marshal(val)
@@ -183,7 +183,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	// root table
 	rootUUID := uuid.NewString()
 	rootOvsUUID := libovsdb.UUID{GoUUID: rootUUID}
-	val[libovsdb.COL_UUID] = rootOvsUUID
+	val[libovsdb.ColUuid] = rootOvsUUID
 	val["name"] = "rootRow"
 	val["refMap"] = libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"t2": t1ovsUUID, "a": libovsdb.UUID{GoUUID: uuid.NewString()}}}
 	keyR := common.NewDataKey("gc", "rootTable", rootUUID)
@@ -257,7 +257,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	// table1
 	t1UUID := uuid.NewString()
 	T1ovsUUID := libovsdb.UUID{GoUUID: t1UUID}
-	val[libovsdb.COL_UUID] = T1ovsUUID
+	val[libovsdb.ColUuid] = T1ovsUUID
 	val["name"] = "t1Row"
 	key1 := common.NewDataKey("gc", "table1", t1UUID)
 	buf1, err := json.Marshal(val)
@@ -269,7 +269,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	// root table
 	rootUUID := uuid.NewString()
 	rootOvsUUID := libovsdb.UUID{GoUUID: rootUUID}
-	val[libovsdb.COL_UUID] = rootOvsUUID
+	val[libovsdb.ColUuid] = rootOvsUUID
 	val["name"] = "rootRow"
 	val["refSet"] = libovsdb.OvsSet{GoSet: []interface{}{T1ovsUUID, libovsdb.UUID{GoUUID: uuid.NewString()}}}
 	keyR := common.NewDataKey("gc", "rootTable", rootUUID)

--- a/pkg/ovsdb/condition_test.go
+++ b/pkg/ovsdb/condition_test.go
@@ -16,7 +16,7 @@ func TestConditionUUID(t *testing.T) {
 	uuid := common.GenerateUUID()
 	goUUID := libovsdb.UUID{GoUUID: uuid}
 
-	cond := []interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}
+	cond := []interface{}{libovsdb.ColUuid, FuncEQ, goUUID}
 	tableSchema, ok := testSchemaSimple.Tables[table]
 	assert.True(t, ok)
 	pCondition, err := NewCondition(&tableSchema, cond, klogr.New())

--- a/pkg/ovsdb/database.go
+++ b/pkg/ovsdb/database.go
@@ -133,7 +133,7 @@ func (con *DatabaseEtcd) AddSchema(schemaFile string) error {
 		return err
 	}
 	var srv _Server.Database
-	if schemaName == INT_SERVER {
+	if schemaName == IntServer {
 		err = con.cache.addDatabaseCache(con.schemas[schemaName], nil, con.log)
 		if err != nil {
 			return err
@@ -163,8 +163,8 @@ func (con *DatabaseEtcd) AddSchema(schemaFile string) error {
 			Sid: *sidSet, Cid: *cidSet}
 	}
 
-	key := common.NewDataKey(INT_SERVER, INT_DATABASES, schemaName)
-	dbCache := con.cache.getDBCache(INT_SERVER)
+	key := common.NewDataKey(IntServer, IntDatabase, schemaName)
+	dbCache := con.cache.getDBCache(IntServer)
 	val, err := json.Marshal(srv)
 	if err != nil {
 		return err
@@ -176,7 +176,7 @@ func (con *DatabaseEtcd) AddSchema(schemaFile string) error {
 }
 
 func (con *DatabaseEtcd) getClusterID() (string, error) {
-	cidKey := common.NewTableKey(INT_SERVER, INT_ClusterIDs).String()
+	cidKey := common.NewTableKey(IntServer, IntClusterID).String()
 	cidTmpValue := uuid.NewString()
 	resp, err := con.cli.Txn(context.Background()).If(clientv3.Compare(clientv3.CreateRevision(cidKey), "=", 0)).Then(clientv3.OpPut(cidKey, cidTmpValue)).Else(clientv3.OpGet(cidKey)).Commit()
 	if err != nil {
@@ -196,13 +196,13 @@ func (con *DatabaseEtcd) GetDBSchema(dbName string) (*libovsdb.DatabaseSchema, b
 
 func (con *DatabaseEtcd) GetDBCache(dbName string) (*databaseCache, error) {
 	if con.cache == nil {
-		err := errors.New(E_INTERNAL_ERROR)
+		err := errors.New(ErrInternalError)
 		con.log.V(1).Info("Cache is not created")
 		return nil, err
 	}
 	dbCache, ok := con.cache[dbName]
 	if !ok {
-		err := errors.New(E_INTERNAL_ERROR)
+		err := errors.New(ErrInternalError)
 		con.log.V(1).Info("Database cache is not created", "dbName", dbName)
 		return nil, err
 	}

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -67,7 +67,7 @@ func (ch *Handler) Transact(ctx context.Context, params []interface{}) (interfac
 	}
 	schema, ok := ch.db.GetDBSchema(ovsReq.DBName)
 	if !ok {
-		err := errors.New(E_INTERNAL_ERROR)
+		err := errors.New(ErrInternalError)
 		log.V(1).Info("Unknown schema", "dbName", ovsReq.DBName)
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (ch *Handler) Transact(ctx context.Context, params []interface{}) (interfac
 	}
 	txn, err := NewTransaction(ctx, ch.etcdClient, ovsReq, dbCache, schema, log)
 	if err != nil {
-		return nil, errors.New(E_INTERNAL_ERROR)
+		return nil, errors.New(ErrInternalError)
 	}
 	ch.mu.RLock()
 	monitor, thereIsMonitor := ch.monitors[txn.request.DBName]
@@ -400,7 +400,7 @@ func (ch *Handler) notifyAll(revision int64) {
 func (ch *Handler) monitorCanceledNotification(jsonValue interface{}) {
 	if ch.closed {
 		ch.log.V(5).Info("monitorCanceledNotification", "jsonValue", jsonValue)
-		err := ch.jrpcServer.Notify(ch.handlerContext, MONITOR_CANCELED, jsonValue)
+		err := ch.jrpcServer.Notify(ch.handlerContext, MonitorCanceled, jsonValue)
 		if err != nil {
 			// Usually we get this error because a client closed his connection, so we don't need to inform it as an error
 			ch.log.V(6).Info("monitorCanceledNotification failed", "error", err.Error())
@@ -476,7 +476,7 @@ func (ch *Handler) addMonitor(params []interface{}, notificationType ovsjson.Upd
 		updatersKeys = append(updatersKeys, key)
 	}
 	log := ch.log.WithValues("jsonValue", cmpr.JsonValue)
-	if cmpr.DatabaseName != INT_SERVER {
+	if cmpr.DatabaseName != IntServer {
 		monitor, ok := ch.monitors[cmpr.DatabaseName]
 		if !ok {
 			monitor = ch.db.CreateMonitor(cmpr.DatabaseName, ch, log)

--- a/pkg/ovsdb/monitor.go
+++ b/pkg/ovsdb/monitor.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	MONITOR_CANCELED = "monitor_canceled"
-	UPDATE           = "update"
-	UPDATE2          = "update2"
-	UPDATE3          = "update3"
+	MonitorCanceled = "monitor_canceled"
+	Update          = "update"
+	Update2         = "update2"
+	Update3         = "update3"
 )
 
 type updater struct {
@@ -292,11 +292,11 @@ func (hm *handlerMonitorData) notifier(ch *Handler) {
 				var err error
 				switch hm.notificationType {
 				case ovsjson.Update:
-					err = ch.jrpcServer.Notify(ch.handlerContext, UPDATE, []interface{}{hm.jsonValue, notificationEvent.updates})
+					err = ch.jrpcServer.Notify(ch.handlerContext, Update, []interface{}{hm.jsonValue, notificationEvent.updates})
 				case ovsjson.Update2:
-					err = ch.jrpcServer.Notify(ch.handlerContext, UPDATE2, []interface{}{hm.jsonValue, notificationEvent.updates})
+					err = ch.jrpcServer.Notify(ch.handlerContext, Update2, []interface{}{hm.jsonValue, notificationEvent.updates})
 				case ovsjson.Update3:
-					err = ch.jrpcServer.Notify(ch.handlerContext, UPDATE3, []interface{}{hm.jsonValue, ovsjson.ZERO_UUID, notificationEvent.updates})
+					err = ch.jrpcServer.Notify(ch.handlerContext, Update3, []interface{}{hm.jsonValue, ovsjson.ZERO_UUID, notificationEvent.updates})
 				}
 				if err != nil {
 					// TODO should we do something else
@@ -737,7 +737,7 @@ func (u *updater) prepareRow(row *libovsdb.Row) (map[string]interface{}, string,
 		return nil, "", err
 	}
 	data = u.copySelectedColumns(data)
-	delete(data, libovsdb.COL_UUID)
+	delete(data, libovsdb.ColUuid)
 	return data, uuid.GoUUID, nil
 }
 

--- a/pkg/ovsdb/monitor_test.go
+++ b/pkg/ovsdb/monitor_test.go
@@ -37,20 +37,20 @@ func init() {
 }
 
 const (
-	DB_NAME    = "dbName"
-	TABLE_NAME = "T1"
-	ROW_UUID   = "43f24179-432d-435b-a8dc-e7134cf39e32"
-	LAST_TNX   = "00000000-0000-0000-0000-000000000000"
-	SET_COLUMN = "set"
-	MAP_COLUMN = "map"
-	KEY_PREFIX = "ovsdb/nb"
+	dbName    = "dbName"
+	tableName = "T1"
+	rowUUID   = "43f24179-432d-435b-a8dc-e7134cf39e32"
+	lastTNX   = "00000000-0000-0000-0000-000000000000"
+	setColumn = "set"
+	mapColumn = "map"
+	keyPrefix = "ovsdb/nb"
 )
 
 func TestMonitorPrepareRowCheckColumns(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	data := map[string]interface{}{"c1": "v1", "c2": "v2"}
 	expectedUUID := guuid.NewString()
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	row := &libovsdb.Row{Fields: data}
 
 	// Columns are nil or all columns
@@ -71,11 +71,11 @@ func TestMonitorPrepareRowCheckColumns(t *testing.T) {
 
 func TestMonitorPrepareRowCheckWhere(t *testing.T) {
 	const (
-		SET_COLUMN_0 = SET_COLUMN + "0"
-		SET_COLUMN_1 = SET_COLUMN + "1"
-		SET_COLUMN_2 = SET_COLUMN + "2"
-		MAP_COLUMN_0 = MAP_COLUMN + "0"
-		MAP_COLUMN_1 = MAP_COLUMN + "1"
+		setColumn0 = setColumn + "0"
+		setColumn1 = setColumn + "1"
+		setColumn2 = setColumn + "2"
+		mapColumn0 = mapColumn + "0"
+		mapColumn1 = mapColumn + "1"
 	)
 	tableSchema := createTestTableSchema()
 	set0 := libovsdb.OvsSet{GoSet: nil}
@@ -83,10 +83,10 @@ func TestMonitorPrepareRowCheckWhere(t *testing.T) {
 	set2 := libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}
 	map0 := libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}
 	map1 := libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}
-	dataRow := map[string]interface{}{"c1": "v1", "c2": "v2", "r1": 1.5, "i1": 3, "b1": true, SET_COLUMN_0: set0, SET_COLUMN_1: set1, SET_COLUMN_2: set2, MAP_COLUMN_0: map0, MAP_COLUMN_1: map1}
-	data := map[string]interface{}{"c1": "v1", "c2": "v2", "r1": 1.5, "i1": 3, "b1": true, SET_COLUMN_0: set0, SET_COLUMN_1: set1, SET_COLUMN_2: set2, MAP_COLUMN_0: map0, MAP_COLUMN_1: map1}
-	expectedUUID := ROW_UUID
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	dataRow := map[string]interface{}{"c1": "v1", "c2": "v2", "r1": 1.5, "i1": 3, "b1": true, setColumn0: set0, setColumn1: set1, setColumn2: set2, mapColumn0: map0, mapColumn1: map1}
+	data := map[string]interface{}{"c1": "v1", "c2": "v2", "r1": 1.5, "i1": 3, "b1": true, setColumn0: set0, setColumn1: set1, setColumn2: set2, mapColumn0: map0, mapColumn1: map1}
+	expectedUUID := rowUUID
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	// we need marshal and unmarshal to transfer integers to float64
 	buf, err := json.Marshal(data)
 	assert.Nil(t, err)
@@ -172,87 +172,87 @@ func TestMonitorPrepareRowCheckWhere(t *testing.T) {
 	checkWhere(&[]interface{}{[]interface{}{"b1", "excludes", true}}, emptyRow)
 
 	// Type UUID
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "==", libovsdb.UUID{GoUUID: expectedUUID}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "includes", libovsdb.UUID{GoUUID: expectedUUID}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "!=", libovsdb.UUID{GoUUID: LAST_TNX}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "excludes", libovsdb.UUID{GoUUID: LAST_TNX}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "==", libovsdb.UUID{GoUUID: expectedUUID}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "includes", libovsdb.UUID{GoUUID: expectedUUID}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "!=", libovsdb.UUID{GoUUID: lastTNX}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "excludes", libovsdb.UUID{GoUUID: lastTNX}}}, dataRow)
 
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "==", libovsdb.UUID{GoUUID: LAST_TNX}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "includes", libovsdb.UUID{GoUUID: LAST_TNX}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "!=", libovsdb.UUID{GoUUID: expectedUUID}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{libovsdb.COL_UUID, "excludes", libovsdb.UUID{GoUUID: expectedUUID}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "==", libovsdb.UUID{GoUUID: lastTNX}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "includes", libovsdb.UUID{GoUUID: lastTNX}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "!=", libovsdb.UUID{GoUUID: expectedUUID}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{libovsdb.ColUuid, "excludes", libovsdb.UUID{GoUUID: expectedUUID}}}, emptyRow)
 
 	// Type Set with Zero elements
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_0, "==", libovsdb.OvsSet{GoSet: []interface{}{}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_0, "includes", libovsdb.OvsSet{GoSet: nil}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_0, "!=", libovsdb.OvsSet{GoSet: nil}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn0, "==", libovsdb.OvsSet{GoSet: []interface{}{}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn0, "includes", libovsdb.OvsSet{GoSet: nil}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn0, "!=", libovsdb.OvsSet{GoSet: nil}}}, emptyRow)
 
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_0, "==", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_0, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_0, "!=", libovsdb.OvsSet{GoSet: nil}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn0, "==", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn0, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn0, "!=", libovsdb.OvsSet{GoSet: nil}}}, emptyRow)
 
 	// Type Set with one element
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "==", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "!=", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "==", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "!=", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
 
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "==", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "includes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "!=", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_1, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "==", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "includes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "!=", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn1, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
 
 	// Type Set with 2 elements
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "==", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "==", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "!=", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"c"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"c", "d"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "==", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "==", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "!=", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"c"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"c", "d"}}}}, dataRow)
 
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "==", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "!=", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "!=", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"c"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a", "b", "c"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{SET_COLUMN_2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"c", "d"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "==", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "!=", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "!=", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"a", "b"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"b", "a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"a"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "excludes", libovsdb.OvsSet{GoSet: []interface{}{"b"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"c"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"a", "b", "c"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{setColumn2, "includes", libovsdb.OvsSet{GoSet: []interface{}{"c", "d"}}}}, emptyRow)
 
 	// Type Map
 
 	// Type Map without any elements
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
 
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_0, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn0, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
 
 	// Type Map with 2 tuples
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key2": "val2"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key3": "val1"}}}}, dataRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val3"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key2": "val2"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key3": "val1"}}}}, dataRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val3"}}}}, dataRow)
 
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2", "key3": "val3"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key2": "val2"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key3": "val1", "key2": "val2"}}}}, emptyRow)
-	checkWhere(&[]interface{}{[]interface{}{MAP_COLUMN_1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val3", "key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "!=", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "==", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "includes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2", "key3": "val3"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1", "key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val1"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key3": "val1", "key2": "val2"}}}}, emptyRow)
+	checkWhere(&[]interface{}{[]interface{}{mapColumn1, "excludes", libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"key1": "val3", "key2": "val2"}}}}, emptyRow)
 }
 
 func checkPrepareRow(t *testing.T, tableSchema *libovsdb.TableSchema, row *libovsdb.Row, isV1 bool, mcr ovsjson.MonitorCondRequest, expRow map[string]interface{}) {
@@ -274,19 +274,19 @@ func createTestTableSchema() *libovsdb.TableSchema {
 	mapColumnType := libovsdb.ColumnType{Key: &libovsdb.BaseType{Type: "string"}, Value: &libovsdb.BaseType{Type: "string"}}
 	mColumnSchema := libovsdb.ColumnSchema{Type: libovsdb.TypeMap, TypeObj: &mapColumnType}
 	tableSchema.Columns = map[string]*libovsdb.ColumnSchema{
-		"c1":              &columnSchemaString,
-		"c2":              &columnSchemaString,
-		"c3":              &columnSchemaString,
-		"c4":              &columnSchemaString,
-		"r1":              &columnSchemaReal,
-		"i1":              &columnSchemaInt,
-		"b1":              &columnSchemaBool,
-		SET_COLUMN + "0":  &sColumnSchema,
-		SET_COLUMN + "1":  &sColumnSchema,
-		SET_COLUMN + "2":  &sColumnSchema,
-		libovsdb.COL_UUID: &columnSchemaUUID,
-		MAP_COLUMN + "0":  &mColumnSchema,
-		MAP_COLUMN + "1":  &mColumnSchema,
+		"c1":             &columnSchemaString,
+		"c2":             &columnSchemaString,
+		"c3":             &columnSchemaString,
+		"c4":             &columnSchemaString,
+		"r1":             &columnSchemaReal,
+		"i1":             &columnSchemaInt,
+		"b1":             &columnSchemaBool,
+		setColumn + "0":  &sColumnSchema,
+		setColumn + "1":  &sColumnSchema,
+		setColumn + "2":  &sColumnSchema,
+		libovsdb.ColUuid: &columnSchemaUUID,
+		mapColumn + "0":  &mColumnSchema,
+		mapColumn + "1":  &mColumnSchema,
 	}
 	return &tableSchema
 }
@@ -296,7 +296,7 @@ func TestMonitorPrepareInitialRow(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	data := map[string]interface{}{"c1": "v1", "c2": "v2"}
 	expectedUUID := guuid.NewString()
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	data1Json, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 	testMonitorPrepareInitialRow_(t, tableSchema, &data1Json, expectedUUID, true)
@@ -339,11 +339,11 @@ func TestMonitorPrepareInsertRow(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	expectedUUID := guuid.NewString()
 	data := map[string]interface{}{"c1": "v1", "c2": "v2"}
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	dataJson, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
-	event := &clientv3.Event{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID),
+	event := &clientv3.Event{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID),
 		Value: dataJson, CreateRevision: 1, ModRevision: 1}}
 	testMonitorPrepareInsertRow_(t, tableSchema, event, expectedUUID, true)
 	testMonitorPrepareInsertRow_(t, tableSchema, event, expectedUUID, false)
@@ -376,13 +376,13 @@ func TestMonitorPrepareDeleteRow(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	expectedUUID := guuid.NewString()
 	data := map[string]interface{}{"c1": "v1", "c2": "v2"}
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	dataJson, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
 	event := &clientv3.Event{Type: mvccpb.DELETE,
-		PrevKv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: dataJson},
-		Kv:     &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID)}}
+		PrevKv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: dataJson},
+		Kv:     &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID)}}
 
 	testMonitorPrepareDeleteRow_(t, tableSchema, event, expectedUUID, true)
 	testMonitorPrepareDeleteRow_(t, tableSchema, event, expectedUUID, false)
@@ -414,7 +414,7 @@ func TestMonitorPrepareModifyRow(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	expectedUUID := guuid.NewString()
 	data := map[string]interface{}{"c1": "v1", "c2": "v2", "c3": "v3"}
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	data1Json, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
@@ -425,8 +425,8 @@ func TestMonitorPrepareModifyRow(t *testing.T) {
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
 	event := &clientv3.Event{Type: mvccpb.PUT,
-		PrevKv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: data1Json},
-		Kv:     &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: data2Json, CreateRevision: 1, ModRevision: 2}}
+		PrevKv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: data1Json},
+		Kv:     &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: data2Json, CreateRevision: 1, ModRevision: 2}}
 
 	testMonitorPrepareModifyRow_(t, tableSchema, event, expectedUUID, true)
 	testMonitorPrepareModifyRow_(t, tableSchema, event, expectedUUID, false)
@@ -460,8 +460,8 @@ func TestMonitorPrepareModifyMapRow(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	expectedUUID := guuid.NewString()
 	colMap := libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k1": "v1", "k2": "v2", "k3": "v3"}}
-	data := map[string]interface{}{"c1": "v1", MAP_COLUMN: colMap}
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data := map[string]interface{}{"c1": "v1", mapColumn: colMap}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	data1Json, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
@@ -472,17 +472,17 @@ func TestMonitorPrepareModifyMapRow(t *testing.T) {
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
 	event := &clientv3.Event{Type: mvccpb.PUT,
-		PrevKv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: data1Json},
-		Kv:     &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: data2Json, CreateRevision: 1, ModRevision: 2}}
+		PrevKv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: data1Json},
+		Kv:     &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: data2Json, CreateRevision: 1, ModRevision: 2}}
 
 	testMapRows := func(isV1 bool) {
 		var expRow *ovsjson.RowUpdate
 
 		if isV1 {
-			expRow = &ovsjson.RowUpdate{Old: &map[string]interface{}{MAP_COLUMN: libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k1": "v1", "k2": "v2", "k3": "v3"}}},
-				New: &map[string]interface{}{"c1": "v1", MAP_COLUMN: libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k1": "v1", "k2": "v3", "k4": "v4"}}}}
+			expRow = &ovsjson.RowUpdate{Old: &map[string]interface{}{mapColumn: libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k1": "v1", "k2": "v2", "k3": "v3"}}},
+				New: &map[string]interface{}{"c1": "v1", mapColumn: libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k1": "v1", "k2": "v3", "k4": "v4"}}}}
 		} else {
-			expRow = &ovsjson.RowUpdate{Modify: &map[string]interface{}{MAP_COLUMN: libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k2": "v3", "k3": "v3", "k4": "v4"}}}}
+			expRow = &ovsjson.RowUpdate{Modify: &map[string]interface{}{mapColumn: libovsdb.OvsMap{GoMap: map[interface{}]interface{}{"k2": "v3", "k3": "v3", "k4": "v4"}}}}
 		}
 		updater := mcrToUpdater(ovsjson.MonitorCondRequest{}, "", tableSchema, isV1, log)
 		validateRowNotification(t, updater, event, expectedUUID, expRow, tableSchema)
@@ -495,28 +495,28 @@ func TestMonitorPrepareModifySetRow(t *testing.T) {
 	tableSchema := createTestTableSchema()
 	expectedUUID := guuid.NewString()
 	colSet := libovsdb.OvsSet{GoSet: []interface{}{"e1", "e2"}}
-	data := map[string]interface{}{"c1": "v1", SET_COLUMN: colSet}
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+	data := map[string]interface{}{"c1": "v1", setColumn: colSet}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 	data1Json, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
 	colSet = libovsdb.OvsSet{GoSet: []interface{}{"e4", "e2"}}
-	data[SET_COLUMN] = colSet
+	data[setColumn] = colSet
 	data2Json, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
 
 	event := &clientv3.Event{Type: mvccpb.PUT,
-		PrevKv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: data1Json},
-		Kv:     &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/" + expectedUUID), Value: data2Json, CreateRevision: 1, ModRevision: 2}}
+		PrevKv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: data1Json},
+		Kv:     &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/" + expectedUUID), Value: data2Json, CreateRevision: 1, ModRevision: 2}}
 
 	testSetRows := func(isV1 bool) {
 		var expRow *ovsjson.RowUpdate
 
 		if isV1 {
-			expRow = &ovsjson.RowUpdate{Old: &map[string]interface{}{SET_COLUMN: libovsdb.OvsSet{GoSet: []interface{}{"e1", "e2"}}},
-				New: &map[string]interface{}{"c1": "v1", SET_COLUMN: libovsdb.OvsSet{GoSet: []interface{}{"e2", "e4"}}}}
+			expRow = &ovsjson.RowUpdate{Old: &map[string]interface{}{setColumn: libovsdb.OvsSet{GoSet: []interface{}{"e1", "e2"}}},
+				New: &map[string]interface{}{"c1": "v1", setColumn: libovsdb.OvsSet{GoSet: []interface{}{"e2", "e4"}}}}
 		} else {
-			expRow = &ovsjson.RowUpdate{Modify: &map[string]interface{}{SET_COLUMN: libovsdb.OvsSet{GoSet: []interface{}{"e1", "e4"}}}}
+			expRow = &ovsjson.RowUpdate{Modify: &map[string]interface{}{setColumn: libovsdb.OvsSet{GoSet: []interface{}{"e1", "e4"}}}}
 		}
 		updater := mcrToUpdater(ovsjson.MonitorCondRequest{}, "", tableSchema, isV1, log)
 		validateRowNotification(t, updater, event, expectedUUID, expRow, tableSchema)
@@ -536,7 +536,7 @@ func validateRowNotification(t *testing.T, updater *updater, event *clientv3.Eve
 
 func TestMonitorModifyRowMap(t *testing.T) {
 
-	const MODIFY = "modify"
+	const modify = "modify"
 
 	type operation map[string]struct {
 		event        clientv3.Event
@@ -545,7 +545,7 @@ func TestMonitorModifyRowMap(t *testing.T) {
 	}
 
 	data := map[string]interface{}{}
-	data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: guuid.NewString()}
+	data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: guuid.NewString()}
 	goMap := map[string]interface{}{}
 	goMap["theSame"] = "v1"
 	goMap["newKey"] = "v1"
@@ -584,17 +584,17 @@ func TestMonitorModifyRowMap(t *testing.T) {
 		updater updater
 		op      operation
 	}{"allColumns-v1": {updater: *mcrToUpdater(ovsjson.MonitorCondRequest{}, "", &tableSchema, true, log),
-		op: operation{MODIFY: {event: clientv3.Event{Type: mvccpb.PUT,
-			PrevKv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "table/000"), Value: oldData},
-			Kv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/uuid"),
+		op: operation{modify: {event: clientv3.Event{Type: mvccpb.PUT,
+			PrevKv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "table/000"), Value: oldData},
+			Kv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/uuid"),
 				Value: newData, CreateRevision: 1, ModRevision: 2}},
 			expRowUpdate: &ovsjson.RowUpdate{
 				Old: &map[string]interface{}{"map": deltaMap},
 				New: &map[string]interface{}{"map": newColMap}}}}},
 		"allColumns-v2": {updater: *mcrToUpdater(ovsjson.MonitorCondRequest{}, "", &tableSchema, false, log),
-			op: operation{MODIFY: {event: clientv3.Event{Type: mvccpb.PUT,
-				PrevKv: &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/000"), Value: oldData},
-				Kv:     &mvccpb.KeyValue{Key: []byte(KEY_PREFIX + "/db/table/000"), Value: newData, CreateRevision: 1, ModRevision: 2}},
+			op: operation{modify: {event: clientv3.Event{Type: mvccpb.PUT,
+				PrevKv: &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/000"), Value: oldData},
+				Kv:     &mvccpb.KeyValue{Key: []byte(keyPrefix + "/db/table/000"), Value: newData, CreateRevision: 1, ModRevision: 2}},
 				expRowUpdate: &ovsjson.RowUpdate{
 					Modify: &map[string]interface{}{"map": deltaMap}}}}},
 	}
@@ -631,12 +631,12 @@ func TestMonitorModifyRowMap(t *testing.T) {
 
 func TestMonitorAddRemoveMonitor(t *testing.T) {
 	const (
-		databaseSchemaName           = "OVN_Northbound"
-		databaseSchemaVer            = "5.31.0"
-		logicalRouterTableSchemaName = "Logical_Router"
-		NB_GlobalTableSchemaName     = "NB_Global"
-		ACL_TableSchemaName          = "ACL"
-		monid                        = "monid"
+		databaseSchemaName       = "OVN_Northbound"
+		databaseSchemaVer        = "5.31.0"
+		schemaLogicalRouterTable = "Logical_Router"
+		schemaNBGlobalTable      = "NB_Global"
+		schemaACLTable           = "ACL"
+		monid                    = "monid"
 	)
 	var (
 		columnsNameKey = map[string]*libovsdb.ColumnSchema{
@@ -657,13 +657,13 @@ func TestMonitorAddRemoveMonitor(t *testing.T) {
 		Name:    databaseSchemaName,
 		Version: databaseSchemaVer,
 		Tables: map[string]libovsdb.TableSchema{
-			logicalRouterTableSchemaName: {
+			schemaLogicalRouterTable: {
 				Columns: columnsNameKey,
 			},
-			NB_GlobalTableSchemaName: {
+			schemaNBGlobalTable: {
 				Columns: columnsNameKey,
 			},
-			ACL_TableSchemaName: {
+			schemaACLTable: {
 				Columns: columnsPriority,
 			},
 		},
@@ -685,13 +685,13 @@ func TestMonitorAddRemoveMonitor(t *testing.T) {
 	}
 
 	jrpcServerMock := jrpcServerMock{
-		expMethod:  MONITOR_CANCELED,
+		expMethod:  MonitorCanceled,
 		expMessage: expMsg,
 		t:          t,
 	}
 	handler.SetConnection(&jrpcServerMock, nil)
 	// add First monitor
-	msg := fmt.Sprintf(`["%s",null,{"%s":[{"columns":[%s]}],"%s":[{"columns":[%s]}]}]`, databaseSchemaName, logicalRouterTableSchemaName, "\"name\"", NB_GlobalTableSchemaName, "")
+	msg := fmt.Sprintf(`["%s",null,{"%s":[{"columns":[%s]}],"%s":[{"columns":[%s]}]}]`, databaseSchemaName, schemaLogicalRouterTable, "\"name\"", schemaNBGlobalTable, "")
 	var params []interface{}
 	err = json.Unmarshal([]byte(msg), &params)
 	assert.Nil(t, err)
@@ -701,18 +701,18 @@ func TestMonitorAddRemoveMonitor(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, handler, monitor.handler)
 	assert.Equal(t, databaseSchemaName, monitor.dataBaseName)
-	updateExpected(databaseSchemaName, logicalRouterTableSchemaName, &[]string{"name"}, nil, true)
-	updateExpected(databaseSchemaName, NB_GlobalTableSchemaName, &[]string{}, nil, true)
+	updateExpected(databaseSchemaName, schemaLogicalRouterTable, &[]string{"name"}, nil, true)
+	updateExpected(databaseSchemaName, schemaNBGlobalTable, &[]string{}, nil, true)
 	assert.Equal(t, expKey2Updaters, monitor.key2Updaters)
 	cloned := cloneKey2Updaters(monitor.key2Updaters)
 
 	// add second monitor
-	msg = fmt.Sprintf(`["%s",["%s","%s"],{"%s":[{"columns":[%s]}]}]`, databaseSchemaName, monid, databaseSchemaName, ACL_TableSchemaName, "\"priority\"")
+	msg = fmt.Sprintf(`["%s",["%s","%s"],{"%s":[{"columns":[%s]}]}]`, databaseSchemaName, monid, databaseSchemaName, schemaACLTable, "\"priority\"")
 	err = json.Unmarshal([]byte(msg), &params)
 	assert.Nil(t, err)
 	_, err = handler.addMonitor(params, ovsjson.Update2)
 	assert.Nil(t, err)
-	updateExpected(databaseSchemaName, ACL_TableSchemaName, &[]string{"priority"}, []interface{}{monid, databaseSchemaName}, false)
+	updateExpected(databaseSchemaName, schemaACLTable, &[]string{"priority"}, []interface{}{monid, databaseSchemaName}, false)
 	assert.Equal(t, expKey2Updaters, monitor.key2Updaters)
 
 	// remove the second monitor
@@ -768,13 +768,13 @@ func TestMonitorNotifications1(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	jrpcServerMock := jrpcServerMock{
-		expMethod: UPDATE,
+		expMethod: Update,
 		t:         t,
 		wg:        &wg,
 	}
 	handler.SetConnection(&jrpcServerMock, nil)
 	handler.startNotifier(jsonValueToString(nil))
-	monitor := handler.monitors[DB_NAME]
+	monitor := handler.monitors[dbName]
 	monitor.notify(events, 1)
 	wg.Wait()
 }
@@ -784,13 +784,13 @@ func TestMonitorNotifications2(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	jrpcServerMock := jrpcServerMock{
-		expMethod: UPDATE2,
+		expMethod: Update2,
 		t:         t,
 		wg:        &wg,
 	}
 	handler.SetConnection(&jrpcServerMock, nil)
 	handler.startNotifier(jsonValueToString(nil))
-	monitor := handler.monitors[DB_NAME]
+	monitor := handler.monitors[dbName]
 	monitor.notify(events, 1)
 	wg.Wait()
 }
@@ -800,13 +800,13 @@ func TestMonitorNotifications3(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	jrpcServerMock := jrpcServerMock{
-		expMethod: UPDATE3,
+		expMethod: Update3,
 		t:         t,
 		wg:        &wg,
 	}
 	handler.SetConnection(&jrpcServerMock, nil)
 	handler.startNotifier(jsonValueToString(nil))
-	monitor := handler.monitors[DB_NAME]
+	monitor := handler.monitors[dbName]
 	monitor.notify(events, 1)
 	wg.Wait()
 }
@@ -854,18 +854,18 @@ func initHandler(t *testing.T, jsonValue string, notificationType ovsjson.Update
 
 	columnSchema := libovsdb.ColumnSchema{Type: libovsdb.TypeString}
 	var testSchemaSimple = &libovsdb.DatabaseSchema{
-		Name: DB_NAME,
+		Name: dbName,
 		Tables: map[string]libovsdb.TableSchema{
-			TABLE_NAME: {Columns: map[string]*libovsdb.ColumnSchema{"c1": &columnSchema, "c2": &columnSchema}},
+			tableName: {Columns: map[string]*libovsdb.ColumnSchema{"c1": &columnSchema, "c2": &columnSchema}},
 		},
 	}
 	schemas := libovsdb.Schemas{}
-	schemas[DB_NAME] = testSchemaSimple
+	schemas[dbName] = testSchemaSimple
 	msg := `["dbName",` + jsonValue + `,{"T1":[{"columns":["c1","c2"]}]}]`
 	row := map[string]interface{}{"c1": "v1", "c2": "v2"}
 	dataJson := prepareData(t, row, true)
-	common.SetPrefix(KEY_PREFIX)
-	keyStr := fmt.Sprintf("%s/%s/%s/000", KEY_PREFIX, DB_NAME, TABLE_NAME)
+	common.SetPrefix(keyPrefix)
+	keyStr := fmt.Sprintf("%s/%s/%s/000", keyPrefix, dbName, tableName)
 	events := []*clientv3.Event{
 		{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte(keyStr), Value: dataJson, CreateRevision: 1, ModRevision: 1}}}
 
@@ -880,14 +880,14 @@ func initHandler(t *testing.T, jsonValue string, notificationType ovsjson.Update
 	_, err = handler.addMonitor(params, notificationType)
 	assert.Nil(t, err)
 
-	_, ok := handler.monitors[DB_NAME]
+	_, ok := handler.monitors[dbName]
 	assert.True(t, ok)
 	return handler, events
 }
 
 func prepareData(t *testing.T, data map[string]interface{}, withUUID bool) []byte {
 	if withUUID {
-		data[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: ROW_UUID}
+		data[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: rowUUID}
 	}
 	dataJson, err := json.Marshal(data)
 	assert.Nilf(t, err, "marshalling %v, threw %v", data, err)
@@ -983,8 +983,8 @@ func TestMonitorCondChange(t *testing.T) {
 		assert.Nil(t, err)
 	}
 	addUuidToRow := func(rowIn map[string]interface{}) (rowOut map[string]interface{}) {
-		expectedUUID := ROW_UUID
-		rowIn[libovsdb.COL_UUID] = libovsdb.UUID{GoUUID: expectedUUID}
+		expectedUUID := rowUUID
+		rowIn[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: expectedUUID}
 		return rowIn
 	}
 	handlerCallToPrepareRow := func(rowInWithoutUUID map[string]interface{}) map[string]interface{} {

--- a/pkg/ovsdb/service.go
+++ b/pkg/ovsdb/service.go
@@ -205,9 +205,9 @@ type Servicer interface {
 }
 
 const (
-	INT_SERVER     = "_Server"
-	INT_DATABASES  = "Database"
-	INT_ClusterIDs = "CID"
+	IntServer    = "_Server"
+	IntDatabase  = "Database"
+	IntClusterID = "CID"
 )
 
 type Service struct {
@@ -217,11 +217,11 @@ type Service struct {
 
 func (s *Service) ListDbs(ctx context.Context, param interface{}) ([]string, error) {
 	klog.V(5).Info("ListDbs request")
-	dbCache, err := s.db.GetDBCache(INT_SERVER)
+	dbCache, err := s.db.GetDBCache(IntServer)
 	if err != nil {
 		return nil, err
 	}
-	tCache := dbCache.getTable(INT_DATABASES)
+	tCache := dbCache.getTable(IntDatabase)
 	dbs := make([]string, 0, len(tCache.rows))
 	for key, _ := range tCache.rows {
 		dbs = append(dbs, key)

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -362,7 +362,7 @@ func TestTransactInsertSimple(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid}},
 			},
 		},
 	}
@@ -465,7 +465,7 @@ func TestTransactInsertSimpleWithUUID(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, uuid}},
 			},
 		},
 	}
@@ -570,7 +570,7 @@ func TestTransactInsertSimpleWithUUIDName(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid}},
 			},
 		},
 	}
@@ -609,7 +609,7 @@ func TestTransactInsertSimpleWithUUIDNameDupError(t *testing.T) {
 	validateInsertResult(t, resp, 2, 0, "")
 	assert.Nil(t, resp.Result[1].Count)
 	assert.NotNil(t, resp.Result[1].Error)
-	assert.Equal(t, E_DUP_UUID_NAME, *resp.Result[1].Error)
+	assert.Equal(t, ErrDuplicateUUIDName, *resp.Result[1].Error)
 	assert.Nil(t, resp.Result[1].Rows)
 }
 
@@ -643,7 +643,7 @@ func TestTransactInsertSimpleWithUUIDDupError(t *testing.T) {
 	validateInsertResult(t, resp, 2, 0, "")
 	assert.Nil(t, resp.Result[1].Count)
 	assert.NotNil(t, resp.Result[1].Error)
-	assert.Equal(t, E_DUP_UUID, *resp.Result[1].Error)
+	assert.Equal(t, ErrDuplicateUUID, *resp.Result[1].Error)
 	assert.Nil(t, resp.Result[1].Rows)
 }
 
@@ -672,7 +672,7 @@ func TestTransactInsertSimpleWithUUIDDupError2(t *testing.T) {
 	resp = testTransact(t, req, testSchemaSimple, 1)
 	assert.Nil(t, resp.Result[0].Count)
 	assert.NotNil(t, resp.Result[0].Error)
-	assert.Equal(t, E_DUP_UUID, *resp.Result[0].Error)
+	assert.Equal(t, ErrDuplicateUUID, *resp.Result[0].Error)
 	assert.Nil(t, resp.Result[0].Rows)
 
 }
@@ -720,7 +720,7 @@ func TestTransactAtomicInsertNamedUUID(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, uuid1}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, uuid1}},
 			},
 		},
 	}
@@ -809,7 +809,7 @@ func TestTransactInsertEnumOk(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid}},
 			},
 		},
 	}
@@ -867,7 +867,7 @@ func TestTransactInsertSetOk(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid}},
 			},
 		},
 	}
@@ -898,7 +898,7 @@ func TestTransactInsertSetError(t *testing.T) {
 	}
 	testEtcdCleanup(t)
 	resp := testTransact(t, req, dbSchemas, 0)
-	validateOperationError(t, resp, 1, 0, E_CONSTRAINT_VIOLATION)
+	validateOperationError(t, resp, 1, 0, ErrConstraintViolation)
 }
 
 func TestTransactUpdateSimple(t *testing.T) {
@@ -999,7 +999,7 @@ func TestTransactUpdateMT(t *testing.T) {
 			Op:    libovsdb.OperationUpdate,
 			Table: &table,
 			Row:   &row2,
-			Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, uuids[i]}},
+			Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, uuids[i]}},
 		}
 	}
 	ops = append(ops, libovsdb.Operation{Op: libovsdb.OperationUpdate, Table: &table, Row: &row3})
@@ -1020,7 +1020,7 @@ func TestTransactUpdateMT(t *testing.T) {
 		ops[i] = libovsdb.Operation{
 			Op:      libovsdb.OperationSelect,
 			Table:   &table,
-			Where:   &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, uuids[i]}},
+			Where:   &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, uuids[i]}},
 			Columns: &[]string{"key1", "key2"},
 		}
 	}
@@ -1071,7 +1071,7 @@ func TestTransactUpdateMapOk(t *testing.T) {
 				Op:    libovsdb.OperationUpdate,
 				Table: &table,
 				Row:   &row2,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid}},
 			},
 		},
 	}
@@ -1085,7 +1085,7 @@ func TestTransactUpdateMapOk(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid}},
 			},
 		},
 	}
@@ -1216,7 +1216,7 @@ func TestTransactUpdateUnmutableError(t *testing.T) {
 		},
 	}
 	resp = testTransact(t, req2, testSchemaMutable, 1)
-	validateOperationError(t, resp, 1, 0, E_CONSTRAINT_VIOLATION)
+	validateOperationError(t, resp, 1, 0, ErrConstraintViolation)
 }
 
 func TestTransactMutateSimple(t *testing.T) {
@@ -1290,14 +1290,14 @@ func TestTransactMutateSetUUID(t *testing.T) {
 	mutations := []interface{}{
 		[]interface{}{
 			"set",
-			MT_DELETE,
+			MtDelete,
 			libovsdb.OvsSet{GoSet: []interface{}{
 				libovsdb.UUID{GoUUID: uuid1},
 			}},
 		},
 		[]interface{}{
 			"set",
-			MT_INSERT,
+			MtInsert,
 			libovsdb.OvsSet{GoSet: []interface{}{
 				libovsdb.UUID{GoUUID: uuid2},
 			}},
@@ -1317,7 +1317,7 @@ func TestTransactMutateSetUUID(t *testing.T) {
 				Op:        libovsdb.OperationMutate,
 				Table:     &table,
 				Mutations: &mutations,
-				Where:     &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}},
+				Where:     &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, goUUID}},
 			},
 		},
 	}
@@ -1359,7 +1359,7 @@ func TestTransactMutateMap(t *testing.T) {
 	mutations := []interface{}{
 		[]interface{}{
 			"string",
-			MT_INSERT,
+			MtInsert,
 			libovsdb.OvsMap{GoMap: map[interface{}]interface{}{
 				"key2": "valueNew1",
 				"key3": "value3",
@@ -1367,7 +1367,7 @@ func TestTransactMutateMap(t *testing.T) {
 		},
 		[]interface{}{
 			"string",
-			MT_INSERT,
+			MtInsert,
 			libovsdb.OvsMap{GoMap: map[interface{}]interface{}{
 				"key2": "valueNew2",
 				"key4": "value4",
@@ -1420,7 +1420,7 @@ func TestTransactMutateMap(t *testing.T) {
 	mutations = []interface{}{
 		[]interface{}{
 			"string",
-			MT_DELETE,
+			MtDelete,
 			libovsdb.OvsMap{GoMap: map[interface{}]interface{}{
 				"key1": "value2", // different value, should not be removed
 				"key2": "value2",
@@ -1428,7 +1428,7 @@ func TestTransactMutateMap(t *testing.T) {
 		},
 		[]interface{}{
 			"string",
-			MT_DELETE,
+			MtDelete,
 			libovsdb.OvsSet{GoSet: []interface{}{"key3", "key4", "key5"}},
 		},
 	}
@@ -1492,7 +1492,7 @@ func TestTransactInsertTwoNamedUUID(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, goUUID1}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, goUUID1}},
 			},
 		},
 	}
@@ -1516,26 +1516,26 @@ func TestTransactMutateSet(t *testing.T) {
 	mutations1 := []interface{}{
 		[]interface{}{
 			"string",
-			MT_INSERT,
+			MtInsert,
 			libovsdb.OvsSet{GoSet: []interface{}{"c", "d"}},
 		},
 	}
 	mutations2 := []interface{}{
 		[]interface{}{
 			"integer",
-			MT_PRODUCT,
+			MtProduct,
 			2,
 		},
 	}
 	mutations3 := []interface{}{
 		[]interface{}{
 			"string",
-			MT_DELETE,
+			MtDelete,
 			libovsdb.OvsSet{GoSet: []interface{}{"b", "d", "e"}},
 		},
 		[]interface{}{
 			"integer",
-			MT_DELETE,
+			MtDelete,
 			libovsdb.OvsSet{GoSet: []interface{}{4, 7}},
 		},
 	}
@@ -1601,27 +1601,27 @@ func TestTransactionSelectByIndex(t *testing.T) {
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"name", FN_EQ, "nameValue"}},
+				Where: &[]interface{}{[]interface{}{"name", FuncEQ, "nameValue"}},
 			},
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"col1", FN_EQ, "col1Value"}, []interface{}{"col2", FN_EQ, "col2Value"}},
+				Where: &[]interface{}{[]interface{}{"col1", FuncEQ, "col1Value"}, []interface{}{"col2", FuncEQ, "col2Value"}},
 			},
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"col1", FN_EQ, "col1Value"}, []interface{}{"col3", FN_EQ, "col3Value"}},
+				Where: &[]interface{}{[]interface{}{"col1", FuncEQ, "col1Value"}, []interface{}{"col3", FuncEQ, "col3Value"}},
 			},
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"col1", FN_EQ, "col1Value"}},
+				Where: &[]interface{}{[]interface{}{"col1", FuncEQ, "col1Value"}},
 			},
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"col1", FN_EQ, "col1Value"}, []interface{}{"name", FN_EQ, "nameValue"}},
+				Where: &[]interface{}{[]interface{}{"col1", FuncEQ, "col1Value"}, []interface{}{"name", FuncEQ, "nameValue"}},
 			},
 		},
 	}
@@ -1679,7 +1679,7 @@ func TestTransactionDeleteInsert(t *testing.T) {
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"name", FN_EQ, "rowName"}},
+				Where: &[]interface{}{[]interface{}{"name", FuncEQ, "rowName"}},
 			},
 			{
 				Op:    libovsdb.OperationInsert,
@@ -1715,7 +1715,7 @@ func TestTransactionDeleteInsert(t *testing.T) {
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{"col3", FN_EQ, "newVal"}},
+				Where: &[]interface{}{[]interface{}{"col3", FuncEQ, "newVal"}},
 			},
 			{
 				Op:    libovsdb.OperationInsert,
@@ -1744,7 +1744,7 @@ func TestTransactDelete(t *testing.T) {
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, goUUID}},
 			},
 		},
 	}
@@ -1767,7 +1767,7 @@ func TestTransactDelete(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, goUUID}},
 			},
 		},
 	}
@@ -1793,7 +1793,7 @@ func TestTransactWaitSimpleEQ(t *testing.T) {
 			"key1": "val1a",
 		},
 	}
-	until := FN_EQ
+	until := FuncEQ
 	req1 := &libovsdb.Transact{
 		DBName: dbName,
 		Operations: []libovsdb.Operation{
@@ -1849,7 +1849,7 @@ func TestTransactWaitSimpleEQColumnsNil(t *testing.T) {
 			"key1": "val1a",
 		},
 	}
-	until := FN_EQ
+	until := FuncEQ
 	req1 := &libovsdb.Transact{
 		DBName: dbName,
 		Operations: []libovsdb.Operation{
@@ -1900,7 +1900,7 @@ func TestTransactWaitSimpleEQRowsEmpty(t *testing.T) {
 	}
 	var rows []map[string]interface{}
 	columns := []string{"key1"}
-	until := FN_EQ
+	until := FuncEQ
 	req1 := &libovsdb.Transact{
 		DBName: dbName,
 		Operations: []libovsdb.Operation{
@@ -1965,7 +1965,7 @@ func TestTransactWaitSimpleNE(t *testing.T) {
 			"key1": "val1c",
 		},
 	}
-	until := FN_NE
+	until := FuncNE
 	req1 := &libovsdb.Transact{
 		DBName: dbName,
 		Operations: []libovsdb.Operation{
@@ -2017,7 +2017,7 @@ func TestTransactWaitSimpleEQError(t *testing.T) {
 			"key1": "val1b",
 		},
 	}
-	until := FN_EQ
+	until := FuncEQ
 	req1 := &libovsdb.Transact{
 		DBName: dbName,
 		Operations: []libovsdb.Operation{
@@ -2046,7 +2046,7 @@ func TestTransactWaitSimpleEQError(t *testing.T) {
 	resp := testTransact(t, req1, testSchemaSimple, 0)
 	assert.Nil(t, resp.Error)
 	resp = testTransact(t, req2, testSchemaSimple, 1)
-	validateOperationError(t, resp, 1, 0, E_TIMEOUT)
+	validateOperationError(t, resp, 1, 0, ErrTimeout)
 }
 
 func TestTransactWaitSimpleNEError(t *testing.T) {
@@ -2062,7 +2062,7 @@ func TestTransactWaitSimpleNEError(t *testing.T) {
 			"key1": "val1a",
 		},
 	}
-	until := FN_NE
+	until := FuncNE
 	req1 := &libovsdb.Transact{
 		DBName: dbName,
 		Operations: []libovsdb.Operation{
@@ -2091,7 +2091,7 @@ func TestTransactWaitSimpleNEError(t *testing.T) {
 	resp := testTransact(t, req1, testSchemaSimple, 0)
 	validateInsertResult(t, resp, 1, 0, "")
 	resp = testTransact(t, req2, testSchemaSimple, 1)
-	validateOperationError(t, resp, 1, 0, E_TIMEOUT)
+	validateOperationError(t, resp, 1, 0, ErrTimeout)
 }
 
 func testColumnDefault(t *testing.T, from interface{}) interface{} {
@@ -2115,7 +2115,7 @@ func TestTransactWaitMapEQ(t *testing.T) {
 	columns := []string{"string"}
 	rows := []map[string]interface{}{row1}
 
-	until := FN_EQ
+	until := FuncEQ
 	req := &libovsdb.Transact{
 		DBName: "map",
 		Operations: []libovsdb.Operation{
@@ -2152,7 +2152,7 @@ func TestTransactCommit(t *testing.T) {
 		},
 	}
 	resp := testTransact(t, req, testSchemaSimple, -1)
-	validateOperationError(t, resp, 1, 0, E_NOT_SUPPORTED)
+	validateOperationError(t, resp, 1, 0, ErrNotSupported)
 }
 
 func TestTransactAbort(t *testing.T) {
@@ -2165,7 +2165,7 @@ func TestTransactAbort(t *testing.T) {
 		},
 	}
 	resp := testTransact(t, req, testSchemaSimple, -1)
-	validateOperationError(t, resp, 1, 0, E_ABORTED)
+	validateOperationError(t, resp, 1, 0, ErrAborted)
 }
 
 func TestTransactSelect(t *testing.T) {
@@ -2189,7 +2189,7 @@ func TestTransactSelect(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, goUUID}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, goUUID}},
 			},
 		},
 	}
@@ -2199,7 +2199,7 @@ func TestTransactSelect(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EX, goUUID}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEX, goUUID}},
 			},
 		},
 	}
@@ -2227,7 +2227,7 @@ func TestTransactSelect(t *testing.T) {
 	validateSelectResult(t, resp, 1, 0, 2)
 	for i := 0; i < 2; i++ {
 		row := (*resp.Result[0].Rows)[i]
-		iUUID, err := libovsdb.UnmarshalUUID(row[libovsdb.COL_UUID])
+		iUUID, err := libovsdb.UnmarshalUUID(row[libovsdb.ColUuid])
 		assert.Nil(t, err)
 		goUUID, ok := iUUID.(libovsdb.UUID)
 		assert.True(t, ok)
@@ -2407,7 +2407,7 @@ func TestTransactGCUpdate(t *testing.T) {
 				Op:    libovsdb.OperationUpdate,
 				Table: &rootTable,
 				Row:   &newRootRow,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuidR}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuidR}},
 			},
 		},
 	}
@@ -2419,7 +2419,7 @@ func TestTransactGCUpdate(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table1,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid1}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid1}},
 			},
 			{
 				Op:    libovsdb.OperationSelect,
@@ -2445,7 +2445,7 @@ func TestTransactGCDelete(t *testing.T) {
 			{
 				Op:    libovsdb.OperationDelete,
 				Table: &rootTable,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuidR}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuidR}},
 			},
 		},
 	}
@@ -2457,7 +2457,7 @@ func TestTransactGCDelete(t *testing.T) {
 			{
 				Op:    libovsdb.OperationSelect,
 				Table: &table1,
-				Where: &[]interface{}{[]interface{}{libovsdb.COL_UUID, FN_EQ, *uuid1}},
+				Where: &[]interface{}{[]interface{}{libovsdb.ColUuid, FuncEQ, *uuid1}},
 			},
 			{
 				Op:    libovsdb.OperationSelect,


### PR DESCRIPTION
Some of the constants were named according to "C" code convention "SOME_CONST". 
Here they were renamed according to Golang convention - "SomeConst"
 
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>