### PR TITLE
Add leader election to the ovsdb-etcd servers

### DIFF
--- a/pkg/ovsdb/cache_test.go
+++ b/pkg/ovsdb/cache_test.go
@@ -107,7 +107,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -124,7 +124,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
@@ -192,7 +192,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -209,7 +209,7 @@ func TestCacheUpdateMap(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
@@ -278,7 +278,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -295,7 +295,7 @@ func TestCacheUpdateSet(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})

--- a/pkg/ovsdb/condition.go
+++ b/pkg/ovsdb/condition.go
@@ -67,7 +67,7 @@ func NewCondition(tableSchema *libovsdb.TableSchema, condition []interface{}, lo
 			return nil, err
 		}
 		value = tmp
-	} else if column == libovsdb.ColUuid { // TODO add libovsdb.COL_VERSION
+	} else if column == libovsdb.ColUuid { // TODO add libovsdb.ColVersion
 		tmp, err := libovsdb.UnmarshalUUID(value)
 		if err != nil {
 			err = errors.New(ErrInternalError)

--- a/pkg/ovsdb/service.go
+++ b/pkg/ovsdb/service.go
@@ -205,9 +205,10 @@ type Servicer interface {
 }
 
 const (
-	IntServer    = "_Server"
-	IntDatabase  = "Database"
-	IntClusterID = "CID"
+	IntServer         = "_Server"
+	IntDatabase       = "Database"
+	IntClusterID      = "CID"
+	IntLeaderElection = "leader-election"
 )
 
 type Service struct {

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -311,7 +311,8 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 		assert.Nil(t, err)
 	}()
 	cache := cache{}
-	err = cache.addDatabaseCache(schema, cli, klogr.New())
+	ctx := context.Background()
+	err = cache.addDatabaseCache(ctx, schema, cli, klogr.New())
 	assert.Nil(t, err)
 	dbCache := cache.getDBCache(schema.Name)
 	if expCacheElements > -1 {
@@ -325,7 +326,7 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 		}
 		assert.Equal(t, expCacheElements, elements)
 	}
-	txn, err := NewTransaction(context.Background(), cli, req, dbCache, schema, klogr.New())
+	txn, err := NewTransaction(ctx, cli, req, dbCache, schema, klogr.New())
 	assert.Nil(t, err)
 	// TODO check error
 	txn.Commit()


### PR DESCRIPTION
When several ovsdb-etcd servers serve concurrently their clients, we cannot guaranty ovsdb database constrains, e.g. uniqueness per index. It can be done only with database locks.
  
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>