### PR TITLE
More strictly implementation of _Server/Database entries

### DIFF
--- a/pkg/libovsdb/schema.go
+++ b/pkg/libovsdb/schema.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	ColUuid     = "_uuid"
-	COL_VERSION = "_version"
+	ColUuid    = "_uuid"
+	ColVersion = "_version"
 )
 
 var DefaultUUID = UUID{"00000000-0000-0000-0000-000000000000"}
@@ -145,7 +145,7 @@ type TableSchema struct {
 }
 
 func (tableSchema *TableSchema) AddInternalColumns() {
-	tableSchema.Columns[COL_VERSION] = &ColumnSchema{
+	tableSchema.Columns[ColVersion] = &ColumnSchema{
 		Type: TypeUUID,
 	}
 	tableSchema.Columns[ColUuid] = &ColumnSchema{
@@ -703,7 +703,7 @@ func (tableSchema *TableSchema) Unmarshal(row *map[string]interface{}) error {
 			var to interface{}
 			var err error
 			switch column {
-			case ColUuid, COL_VERSION:
+			case ColUuid, ColVersion:
 				to, err = UnmarshalUUID(value)
 			default:
 				to, err = columnSchema.Unmarshal(value)

--- a/pkg/ovsdb/database_test.go
+++ b/pkg/ovsdb/database_test.go
@@ -3,14 +3,13 @@ package ovsdb
 import (
 	"context"
 	"fmt"
+	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
 	"path"
 	"testing"
 	"time"
 
-	"k8s.io/klog/v2/klogr"
-
 	"github.com/stretchr/testify/assert"
-	clientv3 "go.etcd.io/etcd/client/v3"
+	etcdClient "go.etcd.io/etcd/client/v3"
 
 	"github.com/ibm/ovsdb-etcd/pkg/common"
 )
@@ -38,7 +37,7 @@ func TestMockAddSchema(t *testing.T) {
 }
 
 func TestMockGetData(t *testing.T) {
-	var expectedResponse *clientv3.GetResponse
+	var expectedResponse *etcdClient.GetResponse
 	var expectedError error
 	mock := DatabaseMock{
 		Error:    expectedError,
@@ -49,11 +48,99 @@ func TestMockGetData(t *testing.T) {
 	assert.Equal(t, expectedResponse, actualResponse)
 }
 
+func TestDatabaseSetDatabase(t *testing.T) {
+	checkEmptySet := func(t *testing.T, v interface{}) {
+		set, ok := v.(libovsdb.OvsSet)
+		assert.True(t, ok)
+		assert.True(t, len(set.GoSet) == 0)
+	}
+	checkUUID := func(t *testing.T, v interface{}) {
+		uuid, ok := v.(libovsdb.UUID)
+		assert.True(t, ok)
+		assert.True(t, len(uuid.GoUUID) > 0)
+	}
+	checkDatabaseRow := func(t *testing.T, row map[string]interface{}, dbName string, expectedModel string) {
+		v, ok := row[libovsdb.ColUuid]
+		assert.True(t, ok)
+		checkUUID(t, v)
+
+		v, ok = row[libovsdb.ColVersion]
+		assert.True(t, ok)
+		checkUUID(t, v)
+
+		v, ok = row[DBColName]
+		assert.True(t, ok)
+		assert.Equal(t, dbName, v)
+
+		v, ok = row[DBColLeader]
+		assert.True(t, ok)
+		if expectedModel == ModStandalone {
+			assert.True(t, v.(bool))
+		} else {
+			assert.False(t, v.(bool))
+		}
+
+		v, ok = row[DBColModel]
+		assert.True(t, ok)
+		assert.Equal(t, expectedModel, v)
+
+		v, ok = row[DBColCID]
+		assert.True(t, ok)
+		if expectedModel == ModStandalone {
+			checkEmptySet(t, v)
+		} else {
+			// TODO
+		}
+
+		v, ok = row[DBColSID]
+		assert.True(t, ok)
+		if expectedModel == ModStandalone {
+			checkEmptySet(t, v)
+		} else {
+			// TODO
+		}
+
+		v, ok = row[DBColIndex]
+		assert.True(t, ok)
+		if expectedModel == ModStandalone {
+			checkEmptySet(t, v)
+		} else {
+			// TODO
+		}
+	}
+	cli, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer cli.Close()
+	ctx := context.Background()
+
+	checkDBModels := func(t *testing.T, model string) {
+		dbs, err := NewDatabaseEtcd(ctx, cli, model, log)
+		assert.Nil(t, err)
+		db := dbs.(*DatabaseEtcd)
+		err = db.AddSchema(path.Join("../../schemas", "_server.ovsschema"))
+		assert.Nil(t, err)
+		err = db.AddSchema(path.Join("../../schemas", "ovn-nb.ovsschema"))
+		assert.Nil(t, err)
+		dbCache, err := db.GetDBCache(IntServer)
+		assert.Nil(t, err)
+
+		tCache := dbCache.getTable(IntDatabase)
+		cRow, ok := tCache.rows[IntServer]
+		assert.True(t, ok)
+		checkDatabaseRow(t, cRow.row.Fields, IntServer, ModStandalone)
+		cRow, ok = tCache.rows[db.dbName]
+		assert.True(t, ok)
+		checkDatabaseRow(t, cRow.row.Fields, db.dbName, db.model)
+	}
+	checkDBModels(t, ModStandalone)
+	checkDBModels(t, ModClustered)
+}
+
 func TestDatabaseEtcdLeaderElection(t *testing.T) {
 	size := 3
 	ctx := context.Background()
 	dbs := make([]*DatabaseEtcd, size, size)
-	cli := make([]*clientv3.Client, size, size)
+	cli := make([]*etcdClient.Client, size, size)
 	var err error
 	for i := 0; i < size; i++ {
 		cli[i], err = testEtcdNewCli()
@@ -67,9 +154,8 @@ func TestDatabaseEtcdLeaderElection(t *testing.T) {
 			}
 		}
 	}()
-	log := klogr.New()
 	for i := 0; i < size; i++ {
-		db, err := NewDatabaseEtcd(ctx, cli[i], Clustered, log)
+		db, err := NewDatabaseEtcd(ctx, cli[i], ModClustered, log)
 		assert.Nil(t, err)
 		dbs[i] = db.(*DatabaseEtcd)
 		err = db.AddSchema(path.Join("../../schemas", "_server.ovsschema"))
@@ -137,7 +223,8 @@ func isLeader(t *testing.T, db *DatabaseEtcd) bool {
 	tCache := dbCache.getTable(IntDatabase)
 	cRow, ok := tCache.rows[db.dbName]
 	assert.True(t, ok)
-	leader, ok := cRow.row.Fields["leader"]
+	fmt.Printf("row %v\n", cRow.row.Fields)
+	leader, ok := cRow.row.Fields[DBColLeader]
 	if !ok {
 		return false
 	}

--- a/pkg/ovsdb/mutation.go
+++ b/pkg/ovsdb/mutation.go
@@ -373,7 +373,7 @@ func (m *Mutation) mutateMap(row *map[string]interface{}) error {
 func (m *Mutation) Mutate(row *map[string]interface{}) error {
 	var err error
 	switch m.column {
-	case libovsdb.ColUuid, libovsdb.COL_VERSION:
+	case libovsdb.ColUuid, libovsdb.ColVersion:
 		err = errors.New(ErrConstraintViolation)
 		m.log.Error(err, "can't mutate column", "column", m.column)
 		return err

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -652,7 +652,7 @@ func setRowUUID(row *map[string]interface{}, uuid string) {
 
 func setRowVersion(row *map[string]interface{}) {
 	version := common.GenerateUUID()
-	(*row)[libovsdb.COL_VERSION] = libovsdb.UUID{GoUUID: version}
+	(*row)[libovsdb.ColVersion] = libovsdb.UUID{GoUUID: version}
 }
 
 /*func (txn *Transaction) getUUIDIfExists(tableSchema *libovsdb.TableSchema, mapUUID namedUUIDResolver, cond1 interface{}) (string, error) {
@@ -798,7 +798,7 @@ func (txn *Transaction) rowUpdate(tableSchema *libovsdb.TableSchema, mapUUID nam
 			return nil, err
 		}
 		switch column {
-		case libovsdb.ColUuid, libovsdb.COL_VERSION:
+		case libovsdb.ColUuid, libovsdb.ColVersion:
 			err = errors.New(ErrConstraintViolation)
 			txn.log.Error(err, "failed update of column", "column", column)
 			return nil, err


### PR DESCRIPTION
Behavior of ovsdb clients depends on the entries in the  `_Server/Database` table. These entries are generated and set by the ovsdb servers themselves.  
Here we fix some of the small inconsistencies in the settings. 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>