### PR TITLE
rollback context changes

### DIFF
--- a/pkg/cmd/server/server.go
+++ b/pkg/cmd/server/server.go
@@ -131,7 +131,7 @@ func main() {
 		log.Error(err, "cli close")
 	}()
 
-	db, _ := ovsdb.NewDatabaseEtcd(ctx, cli, *deploymentModel, log)
+	db, _ := ovsdb.NewDatabaseEtcd(cli, *deploymentModel, log)
 
 	err = db.AddSchema(path.Join(*schemaBasedir, "_server.ovsschema"))
 	if err != nil {

--- a/pkg/ovsdb/cache.go
+++ b/pkg/ovsdb/cache.go
@@ -86,7 +86,7 @@ func (tc *tableCache) size() int {
 	return len(tc.rows)
 }
 
-func (c *cache) addDatabaseCache(ctx context.Context, dbSchema *libovsdb.DatabaseSchema, etcdClient *clientv3.Client, log logr.Logger) error {
+func (c *cache) addDatabaseCache(dbSchema *libovsdb.DatabaseSchema, etcdClient *clientv3.Client, log logr.Logger) error {
 	dbName := dbSchema.Name
 	if _, ok := (*c)[dbName]; ok {
 		return errors.New("Duplicate DatabaseCache: " + dbName)
@@ -97,14 +97,15 @@ func (c *cache) addDatabaseCache(ctx context.Context, dbSchema *libovsdb.Databas
 	if etcdClient == nil {
 		return nil
 	}
+	ctxt := context.Background()
 	key := common.NewDBPrefixKey(dbName)
-	resp, err := etcdClient.Get(ctx, key.String(), clientv3.WithPrefix())
+	resp, err := etcdClient.Get(ctxt, key.String(), clientv3.WithPrefix())
 	if err != nil {
 		log.Error(err, "get KeyData")
 		return err
 	}
 	err = dbCache.storeValues(resp.Kvs)
-	wch := etcdClient.Watch(clientv3.WithRequireLeader(ctx), key.String(),
+	wch := etcdClient.Watch(clientv3.WithRequireLeader(ctxt), key.String(),
 		clientv3.WithPrefix(),
 		clientv3.WithCreatedNotify(),
 		clientv3.WithRev(resp.Header.Revision))

--- a/pkg/ovsdb/cache_test.go
+++ b/pkg/ovsdb/cache_test.go
@@ -107,7 +107,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -124,7 +124,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
@@ -192,7 +192,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -209,7 +209,7 @@ func TestCacheUpdateMap(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
@@ -278,7 +278,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -295,7 +295,7 @@ func TestCacheUpdateSet(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(nil, testSchemaGC, nil, klogr.New())
+	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})

--- a/pkg/ovsdb/database_test.go
+++ b/pkg/ovsdb/database_test.go
@@ -111,10 +111,9 @@ func TestDatabaseSetDatabase(t *testing.T) {
 	cli, err := testEtcdNewCli()
 	assert.Nil(t, err)
 	defer cli.Close()
-	ctx := context.Background()
 
 	checkDBModels := func(t *testing.T, model string) {
-		dbs, err := NewDatabaseEtcd(ctx, cli, model, log)
+		dbs, err := NewDatabaseEtcd(cli, model, log)
 		assert.Nil(t, err)
 		db := dbs.(*DatabaseEtcd)
 		err = db.AddSchema(path.Join("../../schemas", "_server.ovsschema"))
@@ -138,7 +137,6 @@ func TestDatabaseSetDatabase(t *testing.T) {
 
 func TestDatabaseEtcdLeaderElection(t *testing.T) {
 	size := 3
-	ctx := context.Background()
 	dbs := make([]*DatabaseEtcd, size, size)
 	cli := make([]*etcdClient.Client, size, size)
 	var err error
@@ -155,7 +153,7 @@ func TestDatabaseEtcdLeaderElection(t *testing.T) {
 		}
 	}()
 	for i := 0; i < size; i++ {
-		db, err := NewDatabaseEtcd(ctx, cli[i], ModClustered, log)
+		db, err := NewDatabaseEtcd(cli[i], ModClustered, log)
 		assert.Nil(t, err)
 		dbs[i] = db.(*DatabaseEtcd)
 		err = db.AddSchema(path.Join("../../schemas", "_server.ovsschema"))

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -311,8 +311,7 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 		assert.Nil(t, err)
 	}()
 	cache := cache{}
-	ctx := context.Background()
-	err = cache.addDatabaseCache(ctx, schema, cli, klogr.New())
+	err = cache.addDatabaseCache(schema, cli, klogr.New())
 	assert.Nil(t, err)
 	dbCache := cache.getDBCache(schema.Name)
 	if expCacheElements > -1 {
@@ -326,7 +325,7 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 		}
 		assert.Equal(t, expCacheElements, elements)
 	}
-	txn, err := NewTransaction(ctx, cli, req, dbCache, schema, klogr.New())
+	txn, err := NewTransaction(context.Background(), cli, req, dbCache, schema, klogr.New())
 	assert.Nil(t, err)
 	// TODO check error
 	txn.Commit()


### PR DESCRIPTION
Rollbacks context settings from one of previous PRs, and fixes  "context close" error.
Fixes  "duplicate IP" error
 
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>