### PR TITLE
Fix Select operation to return empty set instead of nil

### DIFF
--- a/pkg/libovsdb/notation.go
+++ b/pkg/libovsdb/notation.go
@@ -227,7 +227,8 @@ func (res *OperationResult) InitUUID(uuid string) {
 }
 
 func (res *OperationResult) InitRows() {
-	res.Rows = new([]ResultRow)
+	r := make([]ResultRow, 0)
+	res.Rows = &r
 }
 
 func (res *OperationResult) InitCount() {


### PR DESCRIPTION
When the "Select" operation does not select any rows it should return an empty set instead of nil.
Before this PR the return value was `[{"rows":null}]` and some client operations such as `ovsdb-client backup` failed.
Now it returns `[{"rows":[]}]`
Signed-off-by: Alexey Roytman <roytman@il.ibm.com>