### PR TITLE
Fix locking operations

### DIFF
--- a/pkg/libovsdb/notation.go
+++ b/pkg/libovsdb/notation.go
@@ -44,6 +44,7 @@ type Operation struct {
 	UUID      *UUID                     `json:"uuid,omitempty"`
 	Comment   *string                   `json:"comment,omitempty"`
 	Durable   *bool                     `json:"durable,omitempty"`
+	Lock      *string                   `json:"lock,omitempty"`
 }
 
 // String, serialize Transact

--- a/pkg/ovsdb/database_test.go
+++ b/pkg/ovsdb/database_test.go
@@ -1,9 +1,7 @@
 package ovsdb
 
 import (
-	"context"
 	"fmt"
-	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
 	"path"
 	"testing"
 	"time"
@@ -12,20 +10,8 @@ import (
 	etcdClient "go.etcd.io/etcd/client/v3"
 
 	"github.com/ibm/ovsdb-etcd/pkg/common"
+	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
 )
-
-func TestMockLock(t *testing.T) {
-	expectedResponse := &LockerMock{}
-	var expectedError error
-	mock := DatabaseMock{
-		Response: expectedResponse,
-		Error:    expectedError,
-	}
-	context.Background()
-	actualResponse, actualError := mock.GetLock(context.Background(), "id")
-	assert.Equal(t, expectedResponse, actualResponse)
-	assert.Equal(t, expectedError, actualError)
-}
 
 func TestMockAddSchema(t *testing.T) {
 	var expectedError error

--- a/pkg/ovsdb/handler_test.go
+++ b/pkg/ovsdb/handler_test.go
@@ -1,0 +1,158 @@
+package ovsdb
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type JrpcServerMock struct {
+	notifyFunc func(ctx context.Context, method string, params interface{}) error
+	t          *testing.T
+}
+
+func (jsm JrpcServerMock) Wait() error {
+	return nil
+}
+
+func (jsm JrpcServerMock) Stop() {
+}
+
+func (jsm JrpcServerMock) Notify(ctx context.Context, method string, params interface{}) error {
+	return jsm.notifyFunc(ctx, method, params)
+}
+
+func TestHandlerLock2True(t *testing.T) {
+	ctx := context.Background()
+	ctxc, cancel := context.WithCancel(ctx)
+	cli, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer func() {
+		cancel()
+		err := cli.Close()
+		assert.Nil(t, err)
+	}()
+	handler := NewHandler(ctxc, nil, cli, log)
+	defer handler.Cleanup()
+
+	resp, err := handler.Lock(ctxc, "myLock")
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, true)
+
+}
+
+func TestHandlerLockFalse(t *testing.T) {
+	lockID := "myLock"
+
+	ctx := context.Background()
+	ctxc, cancel := context.WithCancel(ctx)
+	cli1, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	cli2, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer func() {
+		cancel()
+		err = cli1.Close()
+		assert.Nil(t, err)
+		err = cli2.Close()
+		assert.Nil(t, err)
+	}()
+	log1 := log.WithValues("handlerID", 1)
+	handler1 := NewHandler(ctxc, nil, cli1, log1)
+	defer handler1.Cleanup()
+	log2 := log.WithValues("handlerID", 2)
+	handler2 := NewHandler(ctxc, nil, cli2, log2)
+	defer handler2.Cleanup()
+
+	flag := false
+	// add notification checkers
+	handler2.jrpcServer = JrpcServerMock{t: t,
+		notifyFunc: func(ctx context.Context, method string, params interface{}) error {
+			assert.Equal(t, locked, method)
+			str, ok := params.([]string)
+			assert.True(t, ok)
+			assert.Equal(t, lockID, str[0])
+			flag = true
+			return nil
+		}}
+	resp, err := handler1.Lock(nil, lockID)
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, true)
+	resp, err = handler2.Lock(nil, lockID)
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, false)
+	handler1.Unlock(nil, lockID)
+	assert.Eventually(t, func() bool { return flag }, time.Second, 10*time.Millisecond)
+}
+
+func TestHandlerLockTrue(t *testing.T) {
+	lockID := "myLock"
+
+	ctx := context.Background()
+	ctxc, cancel := context.WithCancel(ctx)
+	cli1, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	cli2, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer func() {
+		cancel()
+		err = cli1.Close()
+		assert.Nil(t, err)
+		err = cli2.Close()
+		assert.Nil(t, err)
+	}()
+	log1 := log.WithValues("handlerID", 1)
+	handler1 := NewHandler(ctxc, nil, cli1, log1)
+	defer handler1.Cleanup()
+	log2 := log.WithValues("handlerID", 2)
+	handler2 := NewHandler(ctxc, nil, cli2, log2)
+	defer handler2.Cleanup()
+
+	resp, err := handler1.Lock(nil, lockID)
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, true)
+	_, err = handler1.Unlock(nil, lockID)
+	assert.Nil(t, err)
+	resp, err = handler2.Lock(nil, lockID)
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, true)
+}
+
+func TestHandlerLockNotification(t *testing.T) {
+	lockID := "myLock"
+
+	ctx := context.Background()
+	ctxc, cancel := context.WithCancel(ctx)
+	cli1, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	cli2, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer func() {
+		cancel()
+		err = cli1.Close()
+		assert.Nil(t, err)
+		err = cli2.Close()
+		assert.Nil(t, err)
+	}()
+	log1 := log.WithValues("handlerID", 1)
+	handler1 := NewHandler(ctxc, nil, cli1, log1)
+	defer handler1.Cleanup()
+	log2 := log.WithValues("handlerID", 2)
+	handler2 := NewHandler(ctxc, nil, cli2, log2)
+	defer handler2.Cleanup()
+
+	resp, err := handler1.Lock(nil, lockID)
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, true)
+	resp, err = handler2.Lock(nil, lockID)
+	assert.Nil(t, err)
+	validateLockResponse(t, resp, false)
+}
+
+func validateLockResponse(t *testing.T, resp interface{}, expectValue bool) {
+	respMap, ok := resp.(map[string]bool)
+	assert.True(t, ok)
+	assert.Equal(t, expectValue, respMap[locked])
+}

--- a/pkg/ovsdb/lock.go
+++ b/pkg/ovsdb/lock.go
@@ -1,0 +1,83 @@
+package ovsdb
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	"sync"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+)
+
+type databaseLocks struct {
+	sync.Map
+}
+
+func (dbLocks *databaseLocks) getLocker(id string) (*locker, error) {
+	locI, ok := dbLocks.Load(id)
+	if ok {
+		myLock, ok := locI.(*locker)
+		if !ok {
+			return nil, fmt.Errorf("cannot transform to Locker, %T", locI)
+		} else {
+			return myLock, nil
+		}
+	}
+	return nil, nil
+}
+
+func (dbLocks *databaseLocks) unlock(id string) error {
+	locI, ok := dbLocks.LoadAndDelete(id)
+	if !ok || locI == nil {
+		return nil
+	}
+	myLock, ok := locI.(*locker)
+	if !ok {
+		return fmt.Errorf("cannot transform to Locker, %T", locI)
+	}
+	return myLock.unlock()
+}
+
+func (dbLocks *databaseLocks) cleanup(log logr.Logger) {
+	dbLocks.Range(func(key, value interface{}) bool {
+		mLock, ok := value.(*locker)
+		if !ok {
+			log.V(1).Info("cleanup, cannot transform to Locker", "type", fmt.Sprintf("%T", value), "lockID", key)
+			return true
+		}
+		if err := mLock.unlock(); err != nil {
+			log.Error(err, "cannot unlock", "lockID", key)
+			return true
+		}
+		log.V(6).Info("Unlock", "lockID", key)
+		dbLocks.Delete(key)
+		return true
+	})
+}
+
+type locker struct {
+	mutex    *concurrency.Mutex
+	myCancel context.CancelFunc
+	ctx      context.Context
+}
+
+func (l *locker) tryLock() error {
+	return l.mutex.TryLock(l.ctx)
+}
+
+func (l *locker) lock() error {
+	return l.mutex.Lock(l.ctx)
+}
+
+func (l *locker) unlock() error {
+	return l.mutex.Unlock(l.ctx)
+}
+
+func (l *locker) cancel() {
+	l.myCancel()
+}
+
+func (l *locker) isLocked() clientv3.Cmp {
+	return l.mutex.IsOwner()
+}

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -325,7 +325,7 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 		}
 		assert.Equal(t, expCacheElements, elements)
 	}
-	txn, err := NewTransaction(context.Background(), cli, req, dbCache, schema, klogr.New())
+	txn, err := NewTransaction(context.Background(), cli, req, dbCache, schema, &databaseLocks{}, klogr.New())
 	assert.Nil(t, err)
 	// TODO check error
 	txn.Commit()
@@ -1628,7 +1628,7 @@ func TestTransactionSelectByIndex(t *testing.T) {
 
 	cli, err := testEtcdNewCli()
 	assert.Nil(t, err)
-	trx, err := NewTransaction(context.Background(), cli, req, &databaseCache{}, testSchemaIndex, klogr.New())
+	trx, err := NewTransaction(context.Background(), cli, req, &databaseCache{}, testSchemaIndex, &databaseLocks{}, klogr.New())
 	assert.Nil(t, err)
 	ok, err := trx.isSpecificRowSelected(&req.Operations[0])
 	assert.Nil(t, err)


### PR DESCRIPTION
- Add unit tests for OVSDB locking operations, 

- implement transaction "Assert" operation 

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>