### PR TITLE
Add TTL to the leader election session

### DIFF
--- a/pkg/ovsdb/database.go
+++ b/pkg/ovsdb/database.go
@@ -175,7 +175,7 @@ func (con *DatabaseEtcd) StartLeaderElection() {
 		return
 	}
 	// create a sessions to elect a Leader
-	s, err := concurrency.NewSession(con.cli)
+	s, err := concurrency.NewSession(con.cli, concurrency.WithTTL(5))
 	if err != nil {
 		con.log.Error(err, "new session returned")
 	}

--- a/pkg/ovsdb/database_test.go
+++ b/pkg/ovsdb/database_test.go
@@ -172,14 +172,14 @@ func TestDatabaseEtcdLeaderElection(t *testing.T) {
 		}
 	}
 	assert.NotEqual(t, leader, -1)
-	/*  uncomment to validate leader election over a server failure.
+	/*  uncomment to validate leader election over a server failure. */
 	start = time.Now()
 	cli[leader].Close()
 	cli[leader] = nil
 	oldLeader := leader
 	leader = -1
 	log.Info("start reelection loop")
-	for j := 0; j < 100; j++ {
+	for j := 0; j < 10; j++ {
 		for i := 0; i < size; i++ {
 			if i == oldLeader {
 				continue
@@ -198,7 +198,7 @@ func TestDatabaseEtcdLeaderElection(t *testing.T) {
 			time.Sleep(time.Duration(1*j) * time.Second)
 		}
 	}
-	*/
+	assert.NotEqual(t, -1, leader)
 }
 
 func isLeader(t *testing.T, db *DatabaseEtcd) bool {


### PR DESCRIPTION
Add TTL 5 sec to the server leader election process. It will help to faster discover disconnected or shutdown leaders. The default value was 60 sec.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>