### PR TITLE
Add local flag to indicate global lock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ ovnkube-deploy-ha: check-env
 ovnkube-deploy-org: check-env
 	cd ${OVN_KUBERNETES_ROOT} && git checkout d0fdcfbbb2702ed8482a0c1f6ba4561273399fdc
 	cd ${OVN_KUBERNETES_ROOT}/go-controller && make
-	#cd ${OVN_KUBERNETES_ROOT}/dist/images && make fedora
+	cd ${OVN_KUBERNETES_ROOT}/dist/images && make fedora
 	cd ${OVN_KUBERNETES_ROOT}/contrib && ./kind.sh \
 		--ovn-loglevel-nb '-vconsole:dbg -vfile:dbg' \
 		--ovn-loglevel-sb '-vconsole:dbg -vfile:dbg' \
@@ -184,7 +184,7 @@ ovnkube-deploy-org: check-env
 ovnkube-deploy-org-ha: check-env
 	cd ${OVN_KUBERNETES_ROOT} && git checkout d0fdcfbbb2702ed8482a0c1f6ba4561273399fdc
 	cd ${OVN_KUBERNETES_ROOT}/go-controller && make
-	#cd ${OVN_KUBERNETES_ROOT}/dist/images && make fedora
+	cd ${OVN_KUBERNETES_ROOT}/dist/images && make fedora
 	cd ${OVN_KUBERNETES_ROOT}/contrib && ./kind.sh \
 		--ovn-loglevel-nb '-vconsole:dbg -vfile:dbg' \
 		--ovn-loglevel-sb '-vconsole:dbg -vfile:dbg' \

--- a/pkg/ovsdb/transact.go
+++ b/pkg/ovsdb/transact.go
@@ -1256,11 +1256,11 @@ func (txn *Transaction) doAssert(ovsOp *libovsdb.Operation, ovsResult *libovsdb.
 	if err != nil {
 		return err, ""
 	}
-	if v == nil {
+	if v == nil || !v.isLocalLocked() {
 		msg := fmt.Sprintf("there is no lock with ID %s", *ovsOp.Lock)
 		txn.log.V(5).Info(ErrNotOwner, "cause", msg)
 		return errors.New(ErrNotOwner), msg
 	}
-	txn.etcdTrx.appendIf(v.mutex.IsOwner())
+	txn.etcdTrx.appendIf(v.isGlobalLocked())
 	return nil, ""
 }


### PR DESCRIPTION
When an etcd transaction returns succeed=false, we cannot separate why it was not succeeded, it can be because one or more key/values were modified or because the client doesn't hold a lock. 
we don't want to re-run the transaction execution if the client doesn't hold the lock. The PR adds a local flag indicating if the client holds the lock.

Signed-off-by: Alexey Roytman <roytman@il.ibm.com>