### PR TITLE
Shared database monitor

### DIFF
--- a/pkg/ovsdb/cache_test.go
+++ b/pkg/ovsdb/cache_test.go
@@ -107,7 +107,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -124,7 +124,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
@@ -192,7 +192,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -209,7 +209,7 @@ func TestCacheUpdateMap(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
@@ -278,7 +278,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	kv_r := mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 
 	tCache := cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache := tCache.getDBCache("gc")
 
@@ -295,7 +295,7 @@ func TestCacheUpdateSet(t *testing.T) {
 
 	// reset the cache and store values in a different order
 	tCache = cache{}
-	err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
+	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
 	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})

--- a/pkg/ovsdb/cache_test.go
+++ b/pkg/ovsdb/cache_test.go
@@ -114,7 +114,8 @@ func TestCacheUpdateUUID(t *testing.T) {
 	// store values in the cache and check counters
 	ePR := clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_r}
 	ePT2 := clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_t1}
-	dbCache.updateCache([]*clientv3.Event{&ePR, &ePT2})
+	rows := events2Rows(t, []*clientv3.Event{&ePR, &ePT2})
+	dbCache.updateRows(rows)
 	r, ok := dbCache.getRow(keyR)
 	assert.True(t, ok)
 	assert.Equal(t, 0, r.counter)
@@ -127,7 +128,8 @@ func TestCacheUpdateUUID(t *testing.T) {
 	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
-	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
+	rows = events2Rows(t, []*clientv3.Event{&ePT2, &ePR})
+	dbCache.updateRows(rows)
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	assert.Equal(t, 0, r.counter)
@@ -137,7 +139,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 
 	//remove the root row
 	eDR := clientv3.Event{Type: clientv3.EventTypeDelete, Kv: &kv_r}
-	dbCache.updateCache([]*clientv3.Event{&eDR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&eDR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.False(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -145,7 +147,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	assert.Equal(t, 0, r.counter)
 
 	// return the root row
-	dbCache.updateCache([]*clientv3.Event{&ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -158,7 +160,7 @@ func TestCacheUpdateUUID(t *testing.T) {
 	assert.Nil(t, err)
 	kv_r = mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 	ePR = clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_r}
-	dbCache.updateCache([]*clientv3.Event{&ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -199,7 +201,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	// store values in the cache and check counters
 	ePR := clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_r}
 	ePT2 := clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_t1}
-	dbCache.updateCache([]*clientv3.Event{&ePR, &ePT2})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR, &ePT2}))
 	r, ok := dbCache.getRow(keyR)
 	assert.True(t, ok)
 	assert.Equal(t, 0, r.counter)
@@ -212,7 +214,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
-	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePT2, &ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	assert.Equal(t, 0, r.counter)
@@ -222,7 +224,7 @@ func TestCacheUpdateMap(t *testing.T) {
 
 	//remove the root row
 	eDR := clientv3.Event{Type: clientv3.EventTypeDelete, Kv: &kv_r}
-	dbCache.updateCache([]*clientv3.Event{&eDR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&eDR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.False(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -230,7 +232,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	assert.Equal(t, 0, r.counter)
 
 	// return the root row
-	dbCache.updateCache([]*clientv3.Event{&ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -243,7 +245,7 @@ func TestCacheUpdateMap(t *testing.T) {
 	assert.Nil(t, err)
 	kv_r = mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 	ePR = clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_r}
-	dbCache.updateCache([]*clientv3.Event{&ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -285,7 +287,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	// store values in the cache and check counters
 	ePR := clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_r}
 	ePT2 := clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_t1}
-	dbCache.updateCache([]*clientv3.Event{&ePR, &ePT2})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR, &ePT2}))
 	r, ok := dbCache.getRow(keyR)
 	assert.True(t, ok)
 	assert.Equal(t, 0, r.counter)
@@ -298,7 +300,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	_, err = tCache.addDatabaseCache(testSchemaGC, nil, klogr.New())
 	assert.Nil(t, err)
 	dbCache = tCache.getDBCache("gc")
-	dbCache.updateCache([]*clientv3.Event{&ePT2, &ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePT2, &ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	assert.Equal(t, 0, r.counter)
@@ -308,7 +310,7 @@ func TestCacheUpdateSet(t *testing.T) {
 
 	//remove the root row
 	eDR := clientv3.Event{Type: clientv3.EventTypeDelete, Kv: &kv_r}
-	dbCache.updateCache([]*clientv3.Event{&eDR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&eDR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.False(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -316,7 +318,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	assert.Equal(t, 0, r.counter)
 
 	// return the root row
-	dbCache.updateCache([]*clientv3.Event{&ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -329,7 +331,7 @@ func TestCacheUpdateSet(t *testing.T) {
 	assert.Nil(t, err)
 	kv_r = mvccpb.KeyValue{Key: []byte(keyR.String()), Value: bufR}
 	ePR = clientv3.Event{Type: clientv3.EventTypePut, Kv: &kv_r}
-	dbCache.updateCache([]*clientv3.Event{&ePR})
+	dbCache.updateRows(events2Rows(t, []*clientv3.Event{&ePR}))
 	r, ok = dbCache.getRow(keyR)
 	assert.True(t, ok)
 	r, ok = dbCache.getRow(key1)
@@ -396,4 +398,22 @@ func TestCacheCheckMap(t *testing.T) {
 	counts = checkCounters(map1, map11, libovsdb.TypeMap)
 	assert.Equal(t, 0, counts[val1UUID.GoUUID])
 	assert.Equal(t, 0, counts[val2UUID.GoUUID])
+}
+
+func events2Rows(t *testing.T, events []*clientv3.Event) map[common.Key]*cachedRow {
+	rows := map[common.Key]*cachedRow{}
+	for _, event := range events {
+		strKey := string(event.Kv.Key)
+		key, err := common.ParseKey(strKey)
+		assert.Nil(t, err)
+
+		if event.Type == mvccpb.DELETE {
+			rows[*key] = nil
+		} else {
+			cr, err := newCachedRow(strKey, event.Kv.Value, event.Kv.Version)
+			assert.Nil(t, err)
+			rows[*key] = cr
+		}
+	}
+	return rows
 }

--- a/pkg/ovsdb/database.go
+++ b/pkg/ovsdb/database.go
@@ -65,8 +65,9 @@ func NewEtcdClient(ctx context.Context, endpoints []string, keepAliveTime, keepA
 	cfg := clientv3.Config{
 		Endpoints:          endpoints,
 		Context:            ctx,
+		// TODO propagate these parameters as configurable
 		DialTimeout:        30 * time.Second,
-		MaxCallSendMsgSize: 120 * 1024 * 1024,
+		MaxCallSendMsgSize: 1 * 1024 * 1024 * 1024,
 		MaxCallRecvMsgSize: 0, /* max */
 	}
 	if keepAliveTime > 0 {

--- a/pkg/ovsdb/database.go
+++ b/pkg/ovsdb/database.go
@@ -63,8 +63,8 @@ var EtcdClientTimeout = time.Second
 
 func NewEtcdClient(ctx context.Context, endpoints []string, keepAliveTime, keepAliveTimeout time.Duration) (*clientv3.Client, error) {
 	cfg := clientv3.Config{
-		Endpoints:          endpoints,
-		Context:            ctx,
+		Endpoints: endpoints,
+		Context:   ctx,
 		// TODO propagate these parameters as configurable
 		DialTimeout:        30 * time.Second,
 		MaxCallSendMsgSize: 1 * 1024 * 1024 * 1024,

--- a/pkg/ovsdb/database.go
+++ b/pkg/ovsdb/database.go
@@ -198,7 +198,6 @@ func (con *DatabaseEtcd) StartLeaderElection() {
 			if err != nil {
 				con.log.Error(err, "Leader Election error", "serverId", con.serverID)
 			} else {
-				con.log.V(1).Info("err is nil")
 				break
 			}
 		}
@@ -210,7 +209,7 @@ func (con *DatabaseEtcd) StartLeaderElection() {
 		}
 		cRow.row.Fields[DBColLeader] = true
 		tCache.rows[con.dbName] = cRow
-		con.log.V(1).Info("I'm the leader", "serverID", con.serverID)
+		con.log.V(3).Info("I'm the leader", "serverID", con.serverID)
 		// print to pod log too
 		fmt.Printf("I'm the leader, serverID %s\n", con.serverID)
 	}()
@@ -238,13 +237,13 @@ func (con *DatabaseEtcd) GetDBSchema(dbName string) (*libovsdb.DatabaseSchema, b
 func (con *DatabaseEtcd) GetDBCache(dbName string) (*databaseCache, error) {
 	if con.cache == nil {
 		err := errors.New(ErrInternalError)
-		con.log.V(1).Info("Cache is not created")
+		con.log.Error(err, "cache is not created")
 		return nil, err
 	}
 	dbCache, ok := con.cache[dbName]
 	if !ok {
 		err := errors.New(ErrInternalError)
-		con.log.V(1).Info("Database cache is not created", "dbName", dbName)
+		con.log.Error(err, "database cache is not created", "dbName", dbName)
 		return nil, err
 	}
 	return dbCache, nil
@@ -253,13 +252,13 @@ func (con *DatabaseEtcd) GetDBCache(dbName string) (*databaseCache, error) {
 func (con *DatabaseEtcd) GetDBWatcher(dbName string) (*dbWatcher, error) {
 	if con.watchers == nil {
 		err := errors.New(ErrInternalError)
-		con.log.V(1).Info("dbWatchers are not created")
+		con.log.Error(err, "database watchers are not created")
 		return nil, err
 	}
 	dbWatcher, ok := con.watchers[dbName]
 	if !ok {
 		err := errors.New(ErrInternalError)
-		con.log.V(1).Info("Database watcher is not created", "dbName", dbName)
+		con.log.Error(err, "database watcher is not created", "dbName", dbName)
 		return nil, err
 	}
 	return dbWatcher, nil

--- a/pkg/ovsdb/dbWatcher.go
+++ b/pkg/ovsdb/dbWatcher.go
@@ -2,57 +2,51 @@ package ovsdb
 
 import (
 	"context"
+	"sync"
+
 	"github.com/go-logr/logr"
 	"github.com/ibm/ovsdb-etcd/pkg/common"
 	"go.etcd.io/etcd/api/v3/mvccpb"
-	"sync"
-
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
 
 type cacheListener interface {
-	updateCache([]*clientv3.Event)
+	updateRows(events map[common.Key]*cachedRow)
 }
 
 type dbWatcher struct {
 	// etcdTrx watcher channel
-	watchChannel clientv3.WatchChan
-	// cancel function to close the etcd watcher
-	cancel           context.CancelFunc
+	watchChannel     clientv3.WatchChan
 	cacheListener    cacheListener
-	monitorListeners []*dbMonitor
+	monitorListeners map[*dbMonitor]*dbMonitor
 	mu               sync.Mutex
-	log     		logr.Logger
+	log              logr.Logger
 }
 
 func CreateDBWatcher(dbName string, cli *clientv3.Client, revision int64, logger logr.Logger) *dbWatcher {
 	// TODO propagate context and cancel function (?)
-	ctxt, cancel := context.WithCancel(context.Background())
 	key := common.NewDBPrefixKey(dbName)
-	wch := cli.Watch(clientv3.WithRequireLeader(ctxt), key.String(),
-		clientv3.WithPrefix(),
-		clientv3.WithCreatedNotify(),
-		clientv3.WithPrevKV(),
-		clientv3.WithRev(revision),
-	)
-	return &dbWatcher{watchChannel: wch, cancel: cancel, log: logger}
+	var opts []clientv3.OpOption
+	opts = append(opts, clientv3.WithPrefix())
+	opts = append(opts, clientv3.WithCreatedNotify())
+	opts = append(opts, clientv3.WithPrevKV())
+	if revision > -1 {
+		opts = append(opts, clientv3.WithRev(revision))
+	}
+	wch := cli.Watch(clientv3.WithRequireLeader(context.Background()), key.String(), opts...)
+	return &dbWatcher{watchChannel: wch, monitorListeners: make(map[*dbMonitor]*dbMonitor), log: logger}
 }
 
 func (dbw *dbWatcher) addMonitor(dbm *dbMonitor) {
 	dbw.mu.Lock()
 	defer dbw.mu.Unlock()
-	dbw.monitorListeners = append(dbw.monitorListeners, dbm)
+	dbw.monitorListeners[dbm] = dbm
 }
 
 func (dbw *dbWatcher) removeMonitor(dbm *dbMonitor) {
 	dbw.mu.Lock()
 	defer dbw.mu.Unlock()
-	for i, listener := range dbw.monitorListeners {
-		if listener == dbm {
-			dbw.monitorListeners = append(dbw.monitorListeners[:i], dbw.monitorListeners[i+1:]...)
-			return
-		}
-	}
+	delete(dbw.monitorListeners, dbm)
 }
 
 func (dbw *dbWatcher) start() {
@@ -69,10 +63,9 @@ func (dbw *dbWatcher) start() {
 }
 
 func (dbw *dbWatcher) notify(events []*clientv3.Event, revision int64) {
-	if dbw.cacheListener != nil {
-		dbw.cacheListener.updateCache(events)
-	}
+	// TODO combine ovsdbEvents and newCachedRows
 	ovsdbEvents := make([]*ovsdbNotificationEvent, 0, len(events))
+	newCachedRows := map[common.Key]*cachedRow{}
 	for _, event := range events {
 		ovsdbEvent, err := etcd2ovsdbEvent(event, dbw.log)
 		if err != nil {
@@ -81,8 +74,18 @@ func (dbw *dbWatcher) notify(events []*clientv3.Event, revision int64) {
 			continue
 		}
 		ovsdbEvents = append(ovsdbEvents, ovsdbEvent)
+		if !ovsdbEvent.modifyEvent && !ovsdbEvent.createEvent {
+			newCachedRows[ovsdbEvent.key] = nil
+		} else {
+			newCachedRows[ovsdbEvent.key] = &cachedRow{key: ovsdbEvent.key.String(), row: ovsdbEvent.row, version: event.Kv.Version}
+		}
 	}
-	for _, l := range dbw.monitorListeners {
+	if dbw.cacheListener != nil && len(newCachedRows) > 0 {
+		go dbw.cacheListener.updateRows(newCachedRows)
+	}
+	dbw.mu.Lock()
+	defer dbw.mu.Unlock()
+	for l := range dbw.monitorListeners {
 		go l.notify(ovsdbEvents, revision)
 	}
 }

--- a/pkg/ovsdb/dbWatcher.go
+++ b/pkg/ovsdb/dbWatcher.go
@@ -1,0 +1,88 @@
+package ovsdb
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"github.com/ibm/ovsdb-etcd/pkg/common"
+	"go.etcd.io/etcd/api/v3/mvccpb"
+	"sync"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+)
+
+type cacheListener interface {
+	updateCache([]*clientv3.Event)
+}
+
+type dbWatcher struct {
+	// etcdTrx watcher channel
+	watchChannel clientv3.WatchChan
+	// cancel function to close the etcd watcher
+	cancel           context.CancelFunc
+	cacheListener    cacheListener
+	monitorListeners []*dbMonitor
+	mu               sync.Mutex
+	log     		logr.Logger
+}
+
+func CreateDBWatcher(dbName string, cli *clientv3.Client, revision int64, logger logr.Logger) *dbWatcher {
+	// TODO propagate context and cancel function (?)
+	ctxt, cancel := context.WithCancel(context.Background())
+	key := common.NewDBPrefixKey(dbName)
+	wch := cli.Watch(clientv3.WithRequireLeader(ctxt), key.String(),
+		clientv3.WithPrefix(),
+		clientv3.WithCreatedNotify(),
+		clientv3.WithPrevKV(),
+		clientv3.WithRev(revision),
+	)
+	return &dbWatcher{watchChannel: wch, cancel: cancel, log: logger}
+}
+
+func (dbw *dbWatcher) addMonitor(dbm *dbMonitor) {
+	dbw.mu.Lock()
+	defer dbw.mu.Unlock()
+	dbw.monitorListeners = append(dbw.monitorListeners, dbm)
+}
+
+func (dbw *dbWatcher) removeMonitor(dbm *dbMonitor) {
+	dbw.mu.Lock()
+	defer dbw.mu.Unlock()
+	for i, listener := range dbw.monitorListeners {
+		if listener == dbm {
+			dbw.monitorListeners = append(dbw.monitorListeners[:i], dbw.monitorListeners[i+1:]...)
+			return
+		}
+	}
+}
+
+func (dbw *dbWatcher) start() {
+	go func() {
+		// TODO propagate to monitors
+		for wresp := range dbw.watchChannel {
+			if wresp.Canceled {
+				// TODO: reconnect ?
+				return
+			}
+			dbw.notify(wresp.Events, wresp.Header.Revision)
+		}
+	}()
+}
+
+func (dbw *dbWatcher) notify(events []*clientv3.Event, revision int64) {
+	if dbw.cacheListener != nil {
+		dbw.cacheListener.updateCache(events)
+	}
+	ovsdbEvents := make([]*ovsdbNotificationEvent, 0, len(events))
+	for _, event := range events {
+		ovsdbEvent, err := etcd2ovsdbEvent(event, dbw.log)
+		if err != nil {
+			mvccpbEvent := mvccpb.Event(*event)
+			dbw.log.Error(err, "etcd2ovsdbEvent returned", "event", mvccpbEvent.String())
+			continue
+		}
+		ovsdbEvents = append(ovsdbEvents, ovsdbEvent)
+	}
+	for _, l := range dbw.monitorListeners {
+		go l.notify(ovsdbEvents, revision)
+	}
+}

--- a/pkg/ovsdb/dbWatcher_test.go
+++ b/pkg/ovsdb/dbWatcher_test.go
@@ -1,0 +1,118 @@
+package ovsdb
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/ibm/ovsdb-etcd/pkg/libovsdb"
+	"github.com/ibm/ovsdb-etcd/pkg/ovsjson"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/ibm/ovsdb-etcd/pkg/common"
+)
+
+func TestDBWatcher(t *testing.T) {
+	dbName := "test"
+	key := common.GenerateDataKey(dbName, "table1")
+	value := "test/value"
+	cli, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer cli.Close()
+	tcl := testCacheListener{expectedValue: value, expectedKey: key.String(), t: t}
+
+	dbw := CreateDBWatcher(dbName, cli, 4367)
+	dbw.cacheListener = &tcl
+	dbw.start()
+	cli.Put(context.Background(), key.String(), value)
+	for i := 0; i < 5; i++ {
+		if tcl.cacheUpdated {
+			break
+		}
+		time.Sleep(time.Duration(1*i) * time.Second)
+	}
+	assert.True(t, tcl.cacheUpdated)
+	cli.Delete(context.Background(), dbName, clientv3.WithFromKey())
+}
+
+func TestMonitorWatcher(t *testing.T) {
+	const (
+		dbName    = "OVN_Northbound"
+		tableName = "NB_Global"
+		col1      = "name"
+		col2      = "ipsec"
+		monid     = "monid"
+	)
+	cli, err := testEtcdNewCli()
+	assert.Nil(t, err)
+	defer cli.Close()
+	_, err = cli.Delete(context.Background(), common.GetPrefix(), clientv3.WithFromKey())
+	assert.Nil(t, err)
+	dbs, err := NewDatabaseEtcd(cli, ModStandalone, log)
+	assert.Nil(t, err)
+	db := dbs.(*DatabaseEtcd)
+	err = db.AddSchema(path.Join("../../schemas", "_server.ovsschema"))
+	assert.Nil(t, err)
+	err = db.AddSchema(path.Join("../../schemas", "ovn-nb.ovsschema"))
+	assert.Nil(t, err)
+	ctx := context.Background()
+	handler := NewHandler(ctx, db, cli, log)
+
+	key := common.GenerateDataKey(dbName, tableName)
+	row := map[string]interface{}{}
+	row[col1] = "myName"
+	row[col2] = true
+	row[libovsdb.ColUuid] = libovsdb.UUID{GoUUID: key.UUID}
+	row[libovsdb.ColVersion] = libovsdb.UUID{GoUUID: common.GenerateUUID()}
+	value, err := json.Marshal(row)
+	assert.Nil(t, err)
+	ru := ovsjson.RowUpdate{New: &map[string]interface{}{col1: "myName", col2: true}}
+	notifyMessage := []interface{}{[]interface{}{monid, dbName}, ovsjson.TableUpdates{tableName: ovsjson.TableUpdate{key.UUID: ru}}}
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	jrpcServerMock := jrpcServerMock{
+		expMethod:  Update,
+		expMessage: notifyMessage,
+		wg:         &wg,
+		t:          t,
+	}
+	handler.SetConnection(&jrpcServerMock, nil)
+	msg := fmt.Sprintf(`["%s",["%s","%s"],{"%s":[{"columns":["%s","%s"]}]}]`, dbName, monid, dbName, tableName, col1, col2)
+	var params []interface{}
+	err = json.Unmarshal([]byte(msg), &params)
+	assert.Nil(t, err)
+	jsonValueString := jsonValueToString(params[1])
+	_, err = handler.addMonitor(params, ovsjson.Update)
+	assert.Nil(t, err)
+	handler.startNotifier(jsonValueString)
+	cli.Put(ctx, key.String(), string(value))
+	wg.Wait()
+	// remove the monitor and validate that it was removed from the dbWatcher
+	handler.removeMonitor(params[1], false)
+	dbw, err := dbs.GetDBWatcher(dbName)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(dbw.monitorListeners))
+	_, err = cli.Delete(ctx, common.GetPrefix(), clientv3.WithFromKey())
+	assert.Nil(t, err)
+}
+
+type testCacheListener struct {
+	t             *testing.T
+	expectedKey   string
+	expectedValue string
+	cacheUpdated  bool
+}
+
+func (tcl *testCacheListener) updateCache(events []*clientv3.Event) {
+	for _, event := range events {
+		if string(event.Kv.Key) == tcl.expectedKey && string(event.Kv.Value) == tcl.expectedValue {
+			tcl.cacheUpdated = true
+			return
+		}
+	}
+}

--- a/pkg/ovsdb/handler.go
+++ b/pkg/ovsdb/handler.go
@@ -383,7 +383,7 @@ func (ch *Handler) removeMonitor(jsonValue interface{}, notify bool) error {
 	monitor.removeUpdaters(monitorData.updatersKeys, jsonValueString)
 
 	if !monitor.hasUpdaters() {
-		monitor.cancel()
+		ch.db.RemoveMonitor(monitor)
 		delete(ch.monitors, monitorData.dataBaseName)
 	}
 	delete(ch.handlerMonitorData, jsonValueString)
@@ -435,7 +435,7 @@ func (ch *Handler) addMonitor(params []interface{}, notificationType ovsjson.Upd
 		monitor, ok := ch.monitors[cmpr.DatabaseName]
 		if !ok {
 			monitor = ch.db.CreateMonitor(cmpr.DatabaseName, ch, log)
-			monitor.start()
+			//monitor.start()
 			ch.monitors[cmpr.DatabaseName] = monitor
 		}
 		monitor.addUpdaters(updatersMap)

--- a/pkg/ovsdb/lock.go
+++ b/pkg/ovsdb/lock.go
@@ -43,7 +43,8 @@ func (dbLocks *databaseLocks) cleanup(log logr.Logger) {
 	dbLocks.Range(func(key, value interface{}) bool {
 		mLock, ok := value.(*locker)
 		if !ok {
-			log.V(1).Info("cleanup, cannot transform to Locker", "type", fmt.Sprintf("%T", value), "lockID", key)
+			// should we return error ?
+			log.V(3).Info("cleanup, cannot transform to Locker", "type", fmt.Sprintf("%T", value), "lockID", key)
 			return true
 		}
 		if err := mLock.unlock(); err != nil {

--- a/pkg/ovsdb/monitor.go
+++ b/pkg/ovsdb/monitor.go
@@ -301,10 +301,10 @@ func (hm *handlerMonitorData) notifier(ch *Handler) {
 				}
 			}
 			ch.mu.RLock()
-			dbMonitor, ok := ch.monitors[hm.dataBaseName]
+			monitor, ok := ch.monitors[hm.dataBaseName]
 			ch.mu.RUnlock()
-			if ok && dbMonitor != nil {
-				dbMonitor.tQueue.notificationSent(notificationEvent.revision)
+			if ok && monitor != nil {
+				monitor.tQueue.notificationSent(notificationEvent.revision)
 			} else {
 				hm.log.V(5).Info("dataBase monitor is nil", "dataBaseName", hm.dataBaseName)
 			}

--- a/pkg/ovsdb/monitor_test.go
+++ b/pkg/ovsdb/monitor_test.go
@@ -863,12 +863,10 @@ func initHandler(t *testing.T, jsonValue string, notificationType ovsjson.Update
 	msg := `["dbName",` + jsonValue + `,{"T1":[{"columns":["c1","c2"]}]}]`
 	row := map[string]interface{}{"c1": "v1", "c2": "v2"}
 	dataJson := prepareData(t, row, true)
-	common.SetPrefix(keyPrefix)
 	keyStr := fmt.Sprintf("%s/%s/%s/000", keyPrefix, dbName, tableName)
 	events := []*clientv3.Event{
 		{Type: mvccpb.PUT, Kv: &mvccpb.KeyValue{Key: []byte(keyStr), Value: dataJson, CreateRevision: 1, ModRevision: 1}}}
 
-	//db, _ := NewDatabaseMock()
 	db := DatabaseMock{Response: schemas}
 	ctx := context.Background()
 	handler := NewHandler(ctx, &db, nil, klogr.New())
@@ -918,13 +916,13 @@ func (j *jrpcServerMock) Wait() error {
 
 func (j *jrpcServerMock) Stop() {}
 
-func (j *jrpcServerMock) Notify(_ context.Context, method string, _ interface{}) error {
+func (j *jrpcServerMock) Notify(_ context.Context, method string, message interface{}) error {
 	assert.NotNil(j.t, method)
 	assert.Equal(j.t, j.expMethod, method)
+	assert.Equal(j.t, j.expMessage, message)
 	if j.wg != nil {
 		j.wg.Done()
 	}
-
 	return nil
 }
 

--- a/pkg/ovsdb/transact_test.go
+++ b/pkg/ovsdb/transact_test.go
@@ -311,7 +311,7 @@ func testTransact(t *testing.T, req *libovsdb.Transact, schema *libovsdb.Databas
 		assert.Nil(t, err)
 	}()
 	cache := cache{}
-	err = cache.addDatabaseCache(schema, cli, klogr.New())
+	_, err = cache.addDatabaseCache(schema, cli, klogr.New())
 	assert.Nil(t, err)
 	dbCache := cache.getDBCache(schema.Name)
 	if expCacheElements > -1 {


### PR DESCRIPTION
This PR combines together cache and ovsdb monitors etcd watchers. This will reduce ovsdb=-etcd load because we will unmarshal dat only once. 